### PR TITLE
feat: Add include_unpaired option for block-diagonal MSA format (v0.3.3)

### DIFF
--- a/examples/nims/boltz-2/boltz2_client/__init__.py
+++ b/examples/nims/boltz-2/boltz2_client/__init__.py
@@ -26,7 +26,7 @@ Example:
     >>> print(f"Confidence: {result.confidence_scores[0]:.3f}")
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __author__ = "NVIDIA Corporation"
 __email__ = "bionemo-support@nvidia.com"
 

--- a/examples/nims/boltz-2/boltz2_client/a3m_to_csv_converter.py
+++ b/examples/nims/boltz-2/boltz2_client/a3m_to_csv_converter.py
@@ -1192,6 +1192,11 @@ class A3MToCSVConverter:
         - Rows with the same 'key' across different chain CSVs are paired
         - This enables the model to identify co-evolved sequences from same organisms
         
+        When include_unpaired=True, also includes:
+        - Unpaired sequences in "block-diagonal" format where only one chain has
+          a sequence and others have gaps. This maximizes MSA depth while still
+          providing pairing information where available.
+        
         Args:
             msas: Dictionary mapping chain IDs to parsed A3MMSA objects
             output_path: Optional path to save the combined CSV file
@@ -1204,34 +1209,78 @@ class A3MToCSVConverter:
         # Find paired sequences
         pairs = self.pairing_strategy.find_pairs(msas)
         
+        # Track which sequences have been paired (to find unpaired ones later)
+        paired_sequence_ids: Dict[str, Set[str]] = {chain_id: set() for chain_id in chain_ids}
+        for pair in pairs:
+            for chain_id, seq in pair.items():
+                paired_sequence_ids[chain_id].add(seq.identifier)
+        
         if self.max_pairs:
             pairs = pairs[:self.max_pairs]
         
         logger.info(f"Found {len(pairs)} paired sequence sets across {len(chain_ids)} chains")
         
-        # Extract query sequences
+        # Extract query sequences and their lengths (for gap filling)
         query_sequences = {}
+        query_lengths = {}
         for chain_id, msa in msas.items():
             query = msa.get_query()
             if query:
-                query_sequences[chain_id] = self._clean_sequence(query.sequence)
+                clean_seq = self._clean_sequence(query.sequence)
+                query_sequences[chain_id] = clean_seq
+                query_lengths[chain_id] = len(clean_seq)
+        
+        # Collect unpaired sequences if requested
+        unpaired_sequences: Dict[str, List[A3MSequence]] = {chain_id: [] for chain_id in chain_ids}
+        num_unpaired = 0
+        
+        if self.include_unpaired:
+            for chain_id, msa in msas.items():
+                for seq in msa.sequences:
+                    if seq.is_query:
+                        continue
+                    if seq.identifier not in paired_sequence_ids[chain_id]:
+                        unpaired_sequences[chain_id].append(seq)
+                        num_unpaired += 1
+            
+            logger.info(f"Found {num_unpaired} unpaired sequences to include in block-diagonal format")
+        
+        # Calculate total rows: paired + unpaired (block-diagonal)
+        current_key = len(pairs)  # Start unpaired keys after paired ones
         
         # Build per-chain CSVs (for Boltz2 NIM API)
         csv_per_chain: Dict[str, str] = {}
         for chain_id in chain_ids:
             chain_lines = ["key,sequence"]
+            
+            # Add paired sequences
             for idx, pair in enumerate(pairs, start=1):
                 if chain_id in pair:
                     seq = self._clean_sequence(pair[chain_id].sequence)
                     chain_lines.append(f"{idx},{seq}")
                 else:
                     # Use gaps if sequence not found for this chain
-                    ref_msa = msas[chain_id]
-                    query = ref_msa.get_query()
-                    if query:
-                        gap_seq = '-' * len(self._clean_sequence(query.sequence))
-                        chain_lines.append(f"{idx},{gap_seq}")
+                    gap_seq = '-' * query_lengths.get(chain_id, 0)
+                    chain_lines.append(f"{idx},{gap_seq}")
+            
             csv_per_chain[chain_id] = '\n'.join(chain_lines)
+        
+        # Add unpaired sequences in block-diagonal format
+        if self.include_unpaired:
+            unpaired_key = current_key + 1
+            for source_chain_id in chain_ids:
+                for unpaired_seq in unpaired_sequences[source_chain_id]:
+                    # Add this unpaired sequence to all chain CSVs
+                    for chain_id in chain_ids:
+                        if chain_id == source_chain_id:
+                            # This chain has the sequence
+                            seq = self._clean_sequence(unpaired_seq.sequence)
+                            csv_per_chain[chain_id] += f"\n{unpaired_key},{seq}"
+                        else:
+                            # Other chains get gaps
+                            gap_seq = '-' * query_lengths.get(chain_id, 0)
+                            csv_per_chain[chain_id] += f"\n{unpaired_key},{gap_seq}"
+                    unpaired_key += 1
         
         # Build combined CSV (for reference/documentation)
         csv_lines = ["key,sequence"]
@@ -1242,14 +1291,30 @@ class A3MToCSVConverter:
                     seq = self._clean_sequence(pair[chain_id].sequence)
                     sequences.append(seq)
                 else:
-                    ref_msa = msas[chain_id]
-                    query = ref_msa.get_query()
-                    if query:
-                        sequences.append('-' * len(self._clean_sequence(query.sequence)))
+                    sequences.append('-' * query_lengths.get(chain_id, 0))
             concatenated = ':'.join(sequences)
             csv_lines.append(f"{idx},{concatenated}")
         
+        # Add unpaired sequences to combined CSV in block-diagonal format
+        if self.include_unpaired:
+            unpaired_key = current_key + 1
+            for source_chain_id in chain_ids:
+                for unpaired_seq in unpaired_sequences[source_chain_id]:
+                    sequences = []
+                    for chain_id in chain_ids:
+                        if chain_id == source_chain_id:
+                            seq = self._clean_sequence(unpaired_seq.sequence)
+                            sequences.append(seq)
+                        else:
+                            sequences.append('-' * query_lengths.get(chain_id, 0))
+                    concatenated = ':'.join(sequences)
+                    csv_lines.append(f"{unpaired_key},{concatenated}")
+                    unpaired_key += 1
+        
         csv_content = '\n'.join(csv_lines)
+        
+        total_rows = len(pairs) + (num_unpaired if self.include_unpaired else 0)
+        logger.info(f"Total MSA rows: {total_rows} ({len(pairs)} paired + {num_unpaired if self.include_unpaired else 0} unpaired)")
         
         # Save files if path provided
         output_paths_per_chain = None
@@ -1355,6 +1420,7 @@ def convert_a3m_to_multimer_csv(
     output_path: Optional[Path] = None,
     pairing_strategy: str = "greedy",
     use_tax_id: Optional[bool] = None,  # None = auto-detect (ColabFold default)
+    include_unpaired: bool = False,
     max_pairs: Optional[int] = None
 ) -> ConversionResult:
     """
@@ -1374,6 +1440,10 @@ def convert_a3m_to_multimer_csv(
                              This is how ColabFold behaves.
             - True: Force TaxID pairing (requires OX= or species codes in headers)
             - False: Force UniRef/organism ID pairing (works with standard ColabFold output)
+        include_unpaired: If True, include sequences without cross-chain matches in 
+                         "block-diagonal" format (one chain has sequence, others have gaps).
+                         This maximizes MSA depth while still providing pairing where available.
+                         Default: False (only paired sequences are included)
         max_pairs: Maximum number of pairs to include
         
     Returns:
@@ -1388,6 +1458,12 @@ def convert_a3m_to_multimer_csv(
         ...     # use_tax_id=None means auto-detect (default)
         ... )
         >>> print(f"Created {result.num_pairs} paired sequences")
+        
+        >>> # Include unpaired sequences for maximum MSA depth
+        >>> result = convert_a3m_to_multimer_csv(
+        ...     a3m_files={'A': Path('chain_A.a3m'), 'B': Path('chain_B.a3m')},
+        ...     include_unpaired=True  # Block-diagonal format
+        ... )
     
     ColabFold Compatibility:
         Standard ColabFold A3M files use UniRef100 cluster IDs without TaxID information.
@@ -1417,6 +1493,7 @@ def convert_a3m_to_multimer_csv(
     
     converter = A3MToCSVConverter(
         pairing_strategy=strategy,
+        include_unpaired=include_unpaired,
         max_pairs=max_pairs
     )
     

--- a/examples/nims/boltz-2/boltz2_client/cli.py
+++ b/examples/nims/boltz-2/boltz2_client/cli.py
@@ -1534,10 +1534,12 @@ def screen(ctx, target_sequence, compounds_file, target_name, output_dir, no_aff
 @click.option('--pairing-mode', type=click.Choice(['auto', 'taxid', 'uniref']),
               default='auto',
               help='Pairing identifier mode: auto (default, like ColabFold), taxid, or uniref')
+@click.option('--include-unpaired', is_flag=True, default=False,
+              help='Include unpaired sequences in block-diagonal format (maximizes MSA depth)')
 @click.pass_context
 def convert_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str, 
                         output: str, max_pairs: Optional[int], 
-                        pairing_strategy: str, pairing_mode: str):
+                        pairing_strategy: str, pairing_mode: str, include_unpaired: bool):
     """
     Convert ColabFold A3M monomer MSA files to Boltz2 multimer CSV format.
     
@@ -1607,6 +1609,8 @@ def convert_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
     print_info(f"Output: {output}")
     print_info(f"Pairing strategy: {pairing_strategy}")
     print_info(f"Pairing mode: {pairing_mode}")
+    if include_unpaired:
+        print_info("Include unpaired: Yes (block-diagonal format)")
     if max_pairs:
         print_info(f"Max pairs: {max_pairs}")
     
@@ -1624,6 +1628,7 @@ def convert_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
                 output_path=Path(output),
                 pairing_strategy=pairing_strategy,
                 use_tax_id=use_tax_id,
+                include_unpaired=include_unpaired,
                 max_pairs=max_pairs
             )
             
@@ -1666,6 +1671,8 @@ def convert_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
 @click.option('--pairing-mode', type=click.Choice(['auto', 'taxid', 'uniref']),
               default='auto',
               help='Pairing identifier mode: auto (default), taxid, or uniref')
+@click.option('--include-unpaired', is_flag=True, default=False,
+              help='Include unpaired sequences in block-diagonal format (maximizes MSA depth)')
 @click.option('--recycling-steps', type=int, default=3,
               help='Number of recycling steps (default: 3)')
 @click.option('--sampling-steps', type=int, default=200,
@@ -1675,7 +1682,7 @@ def convert_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
 @click.pass_context
 def multimer_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str, 
                          output: Optional[str], save_csv: bool, save_all: bool,
-                         max_pairs: Optional[int], pairing_mode: str, 
+                         max_pairs: Optional[int], pairing_mode: str, include_unpaired: bool,
                          recycling_steps: int, sampling_steps: int, 
                          diffusion_samples: int):
     """
@@ -1775,10 +1782,12 @@ def multimer_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
                 a3m_files=a3m_file_dict,
                 pairing_strategy='greedy',
                 use_tax_id=use_tax_id,
+                include_unpaired=include_unpaired,
                 max_pairs=max_pairs
             )
             
-            progress.update(task, description=f"✓ Paired {result.num_pairs} sequences")
+            unpaired_msg = " (+ unpaired)" if include_unpaired else ""
+            progress.update(task, description=f"✓ Paired {result.num_pairs} sequences{unpaired_msg}")
         
         print_info(f"Paired sequences: {result.num_pairs}")
         

--- a/examples/nims/boltz-2/examples/A3M_TO_MULTIMER_MSA.md
+++ b/examples/nims/boltz-2/examples/A3M_TO_MULTIMER_MSA.md
@@ -1,413 +1,593 @@
-# Converting ColabFold A3M Files to Boltz2 Multimer Format
+# A3M to Multimer MSA Conversion Guide
 
 This guide explains how to convert ColabFold-generated A3M monomer MSA files into the paired CSV format required by Boltz2 for multimer structure predictions.
 
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Understanding the Problem](#understanding-the-problem)
+3. [How Pairing Works](#how-pairing-works)
+4. [Input: A3M File Format](#input-a3m-file-format)
+5. [Output: Paired CSV Format](#output-paired-csv-format)
+6. [Pairing Strategies](#pairing-strategies)
+7. [Include Unpaired Sequences](#include-unpaired-sequences)
+8. [Usage](#usage)
+   - [Python API](#python-api)
+   - [Command Line Interface](#command-line-interface)
+9. [Configuration Options](#configuration-options)
+10. [Best Practices](#best-practices)
+11. [Troubleshooting](#troubleshooting)
+
+---
+
 ## Overview
 
-When predicting protein complex structures with Boltz2, providing Multiple Sequence Alignments (MSAs) significantly improves prediction quality by capturing co-evolutionary signals between interacting proteins. ColabFold generates individual A3M MSA files for each protein chain, but Boltz2 expects paired MSAs where sequences from the same organism are matched across chains.
-
-This package provides tools to automatically convert ColabFold A3M files to Boltz2's multimer format.
-
-## Quick Start
-
-### One-Command Prediction (Recommended)
-
-The fastest way to predict a complex from A3M files:
-
-```bash
-# Predict complex structure directly from A3M files (all-in-one)
-boltz2 --base-url http://localhost:8002 multimer-msa \
-    chain_A.a3m chain_B.a3m \
-    -c A,B \
-    -o complex.cif
-
-# With custom settings
-boltz2 --base-url http://localhost:8002 multimer-msa \
-    chain_A.a3m chain_B.a3m \
-    -c A,B \
-    -o complex.cif \
-    --sampling-steps 400 \
-    --pairing-mode uniref
-```
-
-### CLI: Convert Only
-
-If you just want to convert A3M files to CSV without prediction:
-
-```bash
-# Default: auto-detect pairing mode (like ColabFold)
-boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv
-
-# Force UniRef ID pairing (works with all ColabFold output)
-boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv --pairing-mode uniref
-
-# Force TaxID pairing (requires taxonomy annotations)
-boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv --pairing-mode taxid
-```
-
-### Python API
-
-```python
-from boltz2_client import (
-    convert_a3m_to_multimer_csv,
-    create_paired_msa_per_chain,
-    save_prediction_outputs,
-    get_prediction_summary
-)
-from pathlib import Path
-
-# Convert A3M files (auto-detect pairing mode)
-result = convert_a3m_to_multimer_csv(
-    a3m_files={'A': Path('chain_A.a3m'), 'B': Path('chain_B.a3m')}
-)
-
-print(f"Created {result.num_pairs} paired sequences")
-
-# Get per-chain MSA structures for Boltz2
-msa_per_chain = create_paired_msa_per_chain(result)
-
-# After prediction, save all outputs with one call
-paths = save_prediction_outputs(
-    response=response,
-    output_dir=Path("results"),
-    base_name="complex",
-    save_scores=True,      # Save confidence scores JSON
-    save_csv=True,         # Save paired CSVs
-    conversion_result=result
-)
-
-# Get prediction quality summary
-summary = get_prediction_summary(response)
-print(f"Confidence: {summary['confidence']:.2f}")
-print(f"Quality: {summary['quality_assessment']}")
-```
-
-## CLI Commands Reference
-
-### `boltz2 multimer-msa` - One-Step Prediction
-
-Converts A3M files and runs prediction in a single command.
-
-```bash
-boltz2 [--base-url URL] multimer-msa [OPTIONS] A3M_FILES...
-```
-
-**Options:**
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `-c, --chain-ids` | (required) | Comma-separated chain IDs (e.g., "A,B") |
-| `-o, --output` | `complex.cif` | Output CIF file path |
-| `--save-csv` | false | Save paired CSV files alongside CIF |
-| `--save-all` | false | Save all outputs: CIF + scores JSON |
-| `--max-pairs` | None | Maximum paired sequences to include |
-| `--pairing-mode` | `auto` | Pairing mode: `auto`, `taxid`, or `uniref` |
-| `--recycling-steps` | 3 | Number of recycling steps |
-| `--sampling-steps` | 200 | Number of diffusion sampling steps |
-| `--diffusion-samples` | 1 | Number of output structures |
-
-**Examples:**
-
-```bash
-# Basic heterodimer
-boltz2 --base-url http://localhost:8002 multimer-msa \
-    chain_A.a3m chain_B.a3m -c A,B
-
-# Trimer with higher quality
-boltz2 --base-url http://localhost:8002 multimer-msa \
-    a.a3m b.a3m c.a3m -c A,B,C \
-    --sampling-steps 400
-
-# Multiple structure predictions
-boltz2 --base-url http://localhost:8002 multimer-msa \
-    chain_A.a3m chain_B.a3m -c A,B \
-    --diffusion-samples 5 \
-    -o complex.cif
-
-# Fast prediction with limited MSA depth
-boltz2 --base-url http://localhost:8002 multimer-msa \
-    chain_A.a3m chain_B.a3m -c A,B \
-    --max-pairs 100 \
-    --sampling-steps 50
-
-# Save all outputs (structure + scores + CSVs)
-boltz2 --base-url http://localhost:8002 multimer-msa \
-    chain_A.a3m chain_B.a3m -c A,B \
-    -o results/complex.cif \
-    --save-all --save-csv
-```
-
-**Output files with `--save-all --save-csv`:**
-```
-results/
-├── complex.cif              # 3D structure (mmCIF format)
-├── complex.scores.json      # All confidence scores and metrics
-├── complex_chain_A.csv      # Paired MSA for chain A
-└── complex_chain_B.csv      # Paired MSA for chain B
-```
-
-**Scores JSON contains:**
-```json
-{
-  "confidence_scores": [0.85],
-  "ptm_scores": [0.82],
-  "iptm_scores": [0.78],
-  "complex_plddt_scores": [0.88],
-  "complex_iplddt_scores": [0.85],
-  "pair_chains_iptm_scores": [...],
-  "metrics": {"total_time_seconds": 5.2, ...}
-}
-```
-
-### Multi-Endpoint Load Balancing
-
-For high-throughput workflows, use multiple Boltz2 NIMs with load balancing:
-
-```bash
-# Use 4 Boltz2 NIM endpoints with automatic load balancing
-boltz2 --multi-endpoint \
-    --base-url "http://localhost:8000,http://localhost:8001,http://localhost:8002,http://localhost:8003" \
-    multimer-msa chain_A.a3m chain_B.a3m -c A,B -o complex.cif
-
-# Specify load balancing strategy
-boltz2 --multi-endpoint \
-    --base-url "http://gpu1:8000,http://gpu2:8000" \
-    --load-balance-strategy round_robin \
-    multimer-msa chain_A.a3m chain_B.a3m -c A,B
-
-# Available strategies: round_robin, least_loaded (default), random
-```
-
-### `boltz2 convert-msa` - Convert Only
-
-Converts A3M files to paired CSV format without running prediction.
-
-```bash
-boltz2 convert-msa [OPTIONS] A3M_FILES...
-```
-
-**Options:**
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `-c, --chain-ids` | (required) | Comma-separated chain IDs |
-| `-o, --output` | (required) | Output CSV file path |
-| `--max-pairs` | None | Maximum paired sequences |
-| `--pairing-strategy` | `greedy` | Strategy: `greedy` or `complete` |
-| `--pairing-mode` | `auto` | Mode: `auto`, `taxid`, or `uniref` |
-
-## How It Works
-
-### The Pairing Problem
-
-For multimer predictions, we need to identify which sequences in different MSAs come from the same organism. This "pairing" allows Boltz2 to learn co-evolutionary patterns between interacting proteins.
+When predicting multimer (protein complex) structures, Boltz2 benefits from **paired MSAs** that capture co-evolutionary signals between interacting proteins. This feature converts separate monomer A3M files from ColabFold into the paired CSV format that Boltz2 understands.
 
 ```
-Chain A MSA:           Chain B MSA:           Paired Result:
->Human_ProteinA        >Human_ProteinB        key=1: HumanA + HumanB
-MKTVRQ...              MVTPEG...              (same organism)
-
->Mouse_ProteinA        >Mouse_ProteinB        key=2: MouseA + MouseB  
-MKTIRQ...              MVSPEG...              (same organism)
-
->Rat_ProteinA          >Chicken_ProteinB      No pair
-MKTLRQ...              MVTPDG...              (different organisms)
+┌─────────────────┐     ┌─────────────────┐
+│  Chain A A3M    │     │  Chain B A3M    │
+│  (monomer MSA)  │     │  (monomer MSA)  │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+         └───────────┬───────────┘
+                     │
+              ┌──────▼──────┐
+              │   Pairing   │
+              │   Engine    │
+              └──────┬──────┘
+                     │
+         ┌───────────┴───────────┐
+         │                       │
+┌────────▼────────┐     ┌────────▼────────┐
+│  Chain A CSV    │     │  Chain B CSV    │
+│  (paired MSA)   │     │  (paired MSA)   │
+└─────────────────┘     └─────────────────┘
 ```
 
-### Pairing Strategies
+---
 
-#### 1. Auto-Detect (Default, ColabFold-style)
+## Understanding the Problem
 
-The converter automatically detects the best pairing mode based on your A3M files:
+### Why Pairing Matters
 
-- If >50% of sequences have TaxIDs → **TaxID pairing**
-- If ≤50% have TaxIDs → **UniRef ID pairing**
+Proteins that interact often co-evolve—when one protein changes, its binding partner may compensate with a corresponding change. This co-evolutionary signal is captured in MSAs when sequences from the **same organism** are aligned together.
 
-```python
-# Auto-detect (recommended)
-result = convert_a3m_to_multimer_csv(
-    a3m_files={'A': 'chain_A.a3m', 'B': 'chain_B.a3m'}
-    # use_tax_id=None (default) triggers auto-detection
-)
+**Example**: If human protein A interacts with human protein B, and mouse protein A interacts with mouse protein B, pairing the human sequences together (and mouse sequences together) reveals correlated mutations that indicate interaction.
+
+### The Challenge
+
+ColabFold generates **separate** A3M files for each protein chain. These files contain homologous sequences from various organisms, but they're not aligned to each other. The challenge is to:
+
+1. Identify which sequences come from the same organism
+2. Pair them together in a format Boltz2 understands
+3. Handle cases where organisms don't have sequences in all chains
+
+---
+
+## How Pairing Works
+
+### Step 1: Parse A3M Files
+
+Each A3M file is parsed to extract:
+- **Sequence**: The amino acid sequence
+- **Identifier**: UniRef cluster ID or UniProt accession
+- **Organism ID**: Used for matching (TaxID or UniRef ID)
+
+### Step 2: Extract Pairing Keys
+
+For each sequence, a "key" is extracted for matching:
+
+| Mode | Key Source | Example |
+|------|------------|---------|
+| **TaxID** | NCBI Taxonomic ID | `9606` (human) |
+| **UniRef** | UniRef cluster ID | `A0A2N5EEG3` |
+
+### Step 3: Match Across Chains
+
+Sequences with the **same key** across different chains are paired:
+
+```
+Chain A MSA:                    Chain B MSA:
+┌─────────────────────┐         ┌─────────────────────┐
+│ Query (human)       │ ←─────→ │ Query (human)       │
+│ Seq1 (TaxID: 9606)  │ ←─────→ │ SeqX (TaxID: 9606)  │  ✓ Paired
+│ Seq2 (TaxID: 10090) │ ←─────→ │ SeqY (TaxID: 10090) │  ✓ Paired
+│ Seq3 (TaxID: 7955)  │         │                     │  ✗ No match
+│                     │         │ SeqZ (TaxID: 562)   │  ✗ No match
+└─────────────────────┘         └─────────────────────┘
 ```
 
-#### 2. UniRef ID Pairing
+### Step 4: Generate Paired CSV
 
-Pairs sequences that share the same UniRef100 cluster ID. Works with **all** ColabFold output.
+Each chain gets its own CSV file with matching keys:
+
+```
+Chain A CSV:              Chain B CSV:
+key,sequence              key,sequence
+1,MKTVRQ...               1,MVTPEG...    ← Same key = paired
+2,MKTVRQ...               2,MVTPEG...    ← Same key = paired
+```
+
+---
+
+## Input: A3M File Format
+
+A3M is a variant of FASTA format used by HHblits/ColabFold. Each sequence has a header line starting with `>` followed by the sequence.
+
+### Supported Header Formats
+
+The converter supports multiple header formats:
+
+#### 1. UniRef Format (ColabFold default)
+```
+>UniRef100_A0A2N5EEG3    340    0.994
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQ
+```
+
+#### 2. UniProt Format
+```
+>tr|A0A0B4J2F2|A0A0B4J2F2_HUMAN
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQ
+```
+- Species code `HUMAN` is mapped to TaxID `9606`
+
+#### 3. With Explicit TaxID (OX field)
+```
+>UniRef100_ABC123 OX=9606 n=5 Tax=Homo sapiens
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQ
+```
+
+#### 4. NCBI Format
+```
+>gi|123|ref|NP_001.1| protein [Homo sapiens]
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQ
+```
+
+---
+
+## Output: Paired CSV Format
+
+Boltz2 expects a simple CSV format with two columns:
+
+| Column | Description |
+|--------|-------------|
+| `key` | Pairing identifier (rows with same key are paired) |
+| `sequence` | Amino acid sequence |
+
+### Example Output
+
+**Chain A CSV** (`paired_chain_A.csv`):
+```csv
+key,sequence
+1,MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+2,MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+3,MKTVRQERLKSIVRILERSKDPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+```
+
+**Chain B CSV** (`paired_chain_B.csv`):
+```csv
+key,sequence
+1,MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAPAD
+2,MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAPAD
+3,MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAERPAD
+```
+
+**Key insight**: Row 1 in Chain A and Row 1 in Chain B have the same key (`1`), so Boltz2 treats them as paired sequences from the same organism.
+
+---
+
+## Pairing Strategies
+
+### Greedy Strategy (Default)
+
+The **greedy** strategy is the default and matches ColabFold's behavior since June 2023.
+
+- Takes the **first** matching sequence for each organism
+- Fast and produces good results for most cases
+- Recommended for general use
 
 ```python
 result = convert_a3m_to_multimer_csv(
     a3m_files={'A': 'chain_A.a3m', 'B': 'chain_B.a3m'},
-    use_tax_id=False  # Force UniRef ID pairing
+    pairing_strategy='greedy'  # Default
 )
 ```
 
-#### 3. TaxID Pairing
+### Complete Strategy
 
-Pairs sequences from the same species using NCBI Taxonomic IDs. Requires A3M files with taxonomy annotations (OX= fields or species codes like `_HUMAN`).
+The **complete** strategy creates all possible pair combinations for each organism.
+
+- If organism X has 3 sequences in Chain A and 2 in Chain B, creates 3×2 = 6 pairs
+- Results in larger MSAs
+- May improve predictions for difficult targets
 
 ```python
 result = convert_a3m_to_multimer_csv(
     a3m_files={'A': 'chain_A.a3m', 'B': 'chain_B.a3m'},
-    use_tax_id=True  # Force TaxID pairing
-)
-```
-
-### Greedy vs Complete Pairing
-
-- **Greedy** (default): Pairs sequences if they match in at least 2 chains
-- **Complete**: Only pairs if ALL chains have a matching sequence
-
-```python
-# Greedy pairing (default, like ColabFold)
-result = convert_a3m_to_multimer_csv(
-    a3m_files={'A': 'a.a3m', 'B': 'b.a3m', 'C': 'c.a3m'},
-    pairing_strategy='greedy'
-)
-
-# Complete pairing (stricter)
-result = convert_a3m_to_multimer_csv(
-    a3m_files={'A': 'a.a3m', 'B': 'b.a3m', 'C': 'c.a3m'},
     pairing_strategy='complete'
 )
 ```
 
-## A3M Header Formats
+---
 
-The converter recognizes multiple header formats:
+## Include Unpaired Sequences
 
-| Format | Example | TaxID Source |
-|--------|---------|--------------|
-| UniProt with species | `>tr\|P12345\|NAME_HUMAN` | Species code → TaxID |
-| Explicit OX field | `>... OX=9606 ...` | OX= field |
-| NCBI with species | `>gi\|123\| [Homo sapiens]` | Species name lookup |
-| UniRef100 only | `>UniRef100_A0A2N5EEG3 340 0.99` | UniRef ID (fallback) |
+By default, only sequences with matches across **all chains** are included. The `include_unpaired` option adds sequences that exist in only some chains using a **block-diagonal format**.
 
-## End-to-End Example
+### What is Block-Diagonal Format?
+
+Unpaired sequences are included with gap characters (`-`) for chains where they don't exist:
+
+```
+Without include_unpaired:          With include_unpaired:
+                                   
+Chain A    Chain B                 Chain A    Chain B
+───────    ───────                 ───────    ───────
+MKTVRQ     MVTPEG  ← paired        MKTVRQ     MVTPEG  ← paired
+MKTVRQ     MVTPEG  ← paired        MKTVRQ     MVTPEG  ← paired
+                                   MKAAYQ     ------  ← A only (block-diagonal)
+                                   ------     MSXYZQ  ← B only (block-diagonal)
+```
+
+### When to Use
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Standard multimer prediction | `include_unpaired=False` (default) |
+| Low sequence coverage | `include_unpaired=True` |
+| Chains from different kingdoms | `include_unpaired=True` |
+| Maximum MSA depth needed | `include_unpaired=True` |
+
+### Usage
 
 ```python
-import asyncio
-from pathlib import Path
+# Python API
+result = convert_a3m_to_multimer_csv(
+    a3m_files={'A': 'chain_A.a3m', 'B': 'chain_B.a3m'},
+    include_unpaired=True
+)
+
+# CLI
+boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv --include-unpaired
+```
+
+### Detailed Example
+
+Given:
+- **Chain A**: Query + organisms {Human, Mouse, Zebrafish, **Yeast**}
+- **Chain B**: Query + organisms {Human, Mouse, Zebrafish, **E.coli**}
+
+**Without `include_unpaired`** (4 rows):
+```
+key  Chain A              Chain B
+───  ───────              ───────
+1    Query                Query
+2    Human seq            Human seq
+3    Mouse seq            Mouse seq
+4    Zebrafish seq        Zebrafish seq
+```
+
+**With `include_unpaired`** (6 rows):
+```
+key  Chain A              Chain B
+───  ───────              ───────
+1    Query                Query
+2    Human seq            Human seq
+3    Mouse seq            Mouse seq
+4    Zebrafish seq        Zebrafish seq
+5    Yeast seq            -----------    ← Block-diagonal
+6    -----------          E.coli seq     ← Block-diagonal
+```
+
+---
+
+## Usage
+
+### Python API
+
+#### Basic Conversion
+
+```python
+from boltz2_client import convert_a3m_to_multimer_csv, create_paired_msa_per_chain
+
+# Convert A3M files to paired CSV
+result = convert_a3m_to_multimer_csv(
+    a3m_files={
+        'A': 'chain_A.a3m',
+        'B': 'chain_B.a3m'
+    },
+    output_path='paired.csv'  # Optional: save to file
+)
+
+print(f"Created {result.num_pairs} paired sequences")
+print(f"Query sequences: {result.query_sequences}")
+```
+
+#### Full Prediction Workflow
+
+```python
 from boltz2_client import (
     Boltz2Client,
     Polymer,
     PredictionRequest,
     convert_a3m_to_multimer_csv,
-    create_paired_msa_per_chain
+    create_paired_msa_per_chain,
+    save_prediction_outputs,
+    get_prediction_summary,
 )
 
-async def predict_complex_with_msa():
-    # 1. Convert A3M files to paired MSA
-    result = convert_a3m_to_multimer_csv(
-        a3m_files={
-            'A': Path('chain_A.a3m'),
-            'B': Path('chain_B.a3m')
-        }
-    )
-    print(f"Paired sequences: {result.num_pairs}")
-    
-    # 2. Create per-chain MSA structures
-    msa_per_chain = create_paired_msa_per_chain(result)
-    
-    # 3. Create polymers with MSA
-    protein_A = Polymer(
-        id="A",
-        molecule_type="protein",
-        sequence=result.query_sequences['A'],
-        msa=msa_per_chain['A']
-    )
-    
-    protein_B = Polymer(
-        id="B",
-        molecule_type="protein",
-        sequence=result.query_sequences['B'],
-        msa=msa_per_chain['B']
-    )
-    
-    # 4. Submit prediction
-    client = Boltz2Client(base_url="http://localhost:8002")
-    
-    request = PredictionRequest(
-        polymers=[protein_A, protein_B],
-        recycling_steps=3,
-        sampling_steps=200,
-        diffusion_samples=1
-    )
-    
-    response = await client.predict(request)
-    
-    # 5. Save structure
-    if response.structures:
-        with open("complex.cif", "w") as f:
-            f.write(response.structures[0].cif_data)
-        print("Structure saved to complex.cif")
+# Step 1: Convert A3M to paired CSV
+result = convert_a3m_to_multimer_csv(
+    a3m_files={'A': 'chain_A.a3m', 'B': 'chain_B.a3m'},
+    include_unpaired=True  # Include all sequences
+)
 
-# Run
-asyncio.run(predict_complex_with_msa())
+# Step 2: Create MSA data structures for each chain
+msa_per_chain = create_paired_msa_per_chain(result)
+
+# Step 3: Build prediction request
+protein_A = Polymer(
+    id='A',
+    molecule_type='protein',
+    sequence=result.query_sequences['A'],
+    msa=msa_per_chain['A']
+)
+
+protein_B = Polymer(
+    id='B',
+    molecule_type='protein',
+    sequence=result.query_sequences['B'],
+    msa=msa_per_chain['B']
+)
+
+request = PredictionRequest(
+    polymers=[protein_A, protein_B],
+    recycling_steps=3,
+    sampling_steps=200
+)
+
+# Step 4: Run prediction
+async with Boltz2Client(base_url="http://localhost:8000") as client:
+    response = await client.predict(request)
+
+# Step 5: Save all outputs
+saved = save_prediction_outputs(
+    response=response,
+    output_dir="results/",
+    base_name="my_complex",
+    save_structure=True,
+    save_scores=True,
+    save_csv=True,
+    conversion_result=result
+)
+
+# Step 6: Get summary
+summary = get_prediction_summary(response)
+print(f"Confidence: {summary['confidence']:.2f}")
+print(f"Quality: {summary['quality_assessment']}")
 ```
 
-## Species to TaxID Mapping
-
-The converter includes multiple methods to resolve species codes to TaxIDs:
-
-1. **Built-in mapping**: 54 common species (instant)
-2. **Bundled speclist.txt**: 27,836 species from UniProt (instant)
-3. **UniProt API**: Online lookup for any species code
-4. **Biopython Entrez**: NCBI Taxonomy lookup for scientific names
+#### Advanced: Custom Pairing Strategy
 
 ```python
-from boltz2_client import SpeciesMapper
+from boltz2_client.a3m_to_csv_converter import (
+    A3MToCSVConverter,
+    GreedyPairingStrategy,
+    CompletePairingStrategy,
+)
 
-# Built-in lookup
-tax_id = SpeciesMapper.get_tax_id("HUMAN")  # "9606"
+# Use complete pairing with TaxID matching
+strategy = CompletePairingStrategy(use_tax_id=True)
+converter = A3MToCSVConverter(
+    pairing_strategy=strategy,
+    include_unpaired=True,
+    max_pairs=1000
+)
 
-# Smart lookup (tries all methods)
-tax_id = SpeciesMapper.smart_lookup("Homo sapiens")  # "9606"
-
-# Check available mappings
-stats = SpeciesMapper.get_mapping_stats()
-print(f"Total species available: {stats['total']}")  # ~27,890
+result = converter.convert_files(
+    a3m_files={'A': 'chain_A.a3m', 'B': 'chain_B.a3m'}
+)
 ```
+
+### Command Line Interface
+
+#### Convert A3M to CSV Only
+
+```bash
+# Basic conversion
+boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv
+
+# With unpaired sequences
+boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv --include-unpaired
+
+# Limit number of pairs
+boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv --max-pairs 500
+
+# Force TaxID or UniRef pairing mode
+boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv --pairing-mode taxid
+boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv --pairing-mode uniref
+```
+
+#### End-to-End Prediction
+
+```bash
+# Basic prediction
+boltz2 multimer-msa chain_A.a3m chain_B.a3m -c A,B
+
+# With custom output and all files saved
+boltz2 multimer-msa chain_A.a3m chain_B.a3m -c A,B \
+    -o my_complex.cif \
+    --save-all \
+    --save-csv
+
+# Include unpaired sequences
+boltz2 multimer-msa chain_A.a3m chain_B.a3m -c A,B --include-unpaired
+
+# Three-chain complex
+boltz2 multimer-msa a.a3m b.a3m c.a3m -c A,B,C -o trimer.cif
+
+# Higher quality prediction
+boltz2 multimer-msa chain_A.a3m chain_B.a3m -c A,B \
+    --sampling-steps 400 \
+    --diffusion-samples 3
+```
+
+---
+
+## Configuration Options
+
+### Pairing Mode (`--pairing-mode` / `use_tax_id`)
+
+| Mode | Description | When to Use |
+|------|-------------|-------------|
+| `auto` | Auto-detect based on A3M content | Default, recommended |
+| `taxid` | Force TaxID-based pairing | A3M has OX= fields or species codes |
+| `uniref` | Force UniRef ID pairing | Standard ColabFold output |
+
+### Pairing Strategy (`--pairing-strategy` / `pairing_strategy`)
+
+| Strategy | Description |
+|----------|-------------|
+| `greedy` | First match per organism (default, ColabFold-style) |
+| `complete` | All combinations per organism |
+| `taxonomy` | Alias for greedy + taxid mode |
+
+### Other Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `include_unpaired` | Include unmatched sequences with gaps | `False` |
+| `max_pairs` | Limit number of paired rows | None (unlimited) |
+| `save_csv` | Save intermediate CSV files | `False` |
+| `save_all` | Save structure, scores, and CSVs | `False` |
+
+---
+
+## Best Practices
+
+### 1. Use Auto-Detection
+
+Let the converter auto-detect the pairing mode:
+
+```python
+result = convert_a3m_to_multimer_csv(
+    a3m_files={'A': 'a.a3m', 'B': 'b.a3m'},
+    use_tax_id=None  # Auto-detect (default)
+)
+```
+
+### 2. Check Pairing Quality
+
+Verify you have enough paired sequences:
+
+```python
+result = convert_a3m_to_multimer_csv(...)
+
+print(f"Paired sequences: {result.num_pairs}")
+if result.num_pairs < 10:
+    print("Warning: Low pairing count. Consider using --include-unpaired")
+```
+
+### 3. Use Include Unpaired for Low Coverage
+
+If your proteins are from different organisms or have low sequence identity:
+
+```python
+result = convert_a3m_to_multimer_csv(
+    a3m_files={'A': 'a.a3m', 'B': 'b.a3m'},
+    include_unpaired=True
+)
+```
+
+### 4. Limit Pairs for Large MSAs
+
+For very large MSAs, limit pairs to improve performance:
+
+```python
+result = convert_a3m_to_multimer_csv(
+    a3m_files={'A': 'a.a3m', 'B': 'b.a3m'},
+    max_pairs=1000
+)
+```
+
+### 5. Save All Outputs for Analysis
+
+Use `save_prediction_outputs()` to save everything:
+
+```python
+saved = save_prediction_outputs(
+    response=response,
+    output_dir="results/",
+    save_structure=True,
+    save_scores=True,
+    save_csv=True,
+    conversion_result=result
+)
+```
+
+---
 
 ## Troubleshooting
 
-### "Only query sequence paired"
+### No Paired Sequences Found
 
-This happens when no common identifiers are found across chains. Solutions:
+**Problem**: `num_pairs = 1` (only query)
 
-1. Use `--pairing-mode uniref` if your files have UniRef IDs
-2. Add taxonomy annotations to your A3M files
-3. Check if your A3M files have overlapping organisms
-
-### "No TaxIDs found"
-
-Standard ColabFold output uses UniRef100 IDs without TaxIDs. Use:
+**Solutions**:
+1. Check if A3M files have TaxID annotations
+2. Try `--pairing-mode uniref` for standard ColabFold output
+3. Use `--include-unpaired` to include all sequences
 
 ```bash
-boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o out.csv --pairing-mode uniref
+# Check A3M headers
+head -20 chain_A.a3m
+
+# Try UniRef mode
+boltz2 convert-msa a.a3m b.a3m -c A,B -o out.csv --pairing-mode uniref
 ```
 
-### Getting TaxID-annotated A3M files
+### Sequence Mismatch Error
 
-1. Run ColabFold with `--use-env-template` flag
-2. Use MMseqs2 to add taxonomy: `mmseqs taxonomy queryDB uniref30 taxDB tmp`
+**Problem**: `First sequence in CSV alignment paired does not match input sequence`
 
-## Output Format
+**Solution**: Ensure the query sequence in Boltz2 request matches the first sequence in your A3M file:
 
-The converter produces CSV files with columns `key` and `sequence`:
-
-```csv
-key,sequence
-1,MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLG
-2,MKTIRQERLKSIIRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLG
-3,MKTLRQERLKSIVRILERSKDPVSGAQLAEELSVSRQVIVQDIAYLRSLG
+```python
+# Use query sequences from conversion result
+protein_A = Polymer(
+    id='A',
+    sequence=result.query_sequences['A'],  # Use this!
+    msa=msa_per_chain['A']
+)
 ```
 
-For Boltz2, each chain gets its own CSV file. Sequences with the same `key` value across chain CSVs are treated as paired (from the same organism).
+### Species Code Not Found
 
-## References
+**Problem**: Warning about unknown species code
 
-- [ColabFold](https://github.com/sokrypton/ColabFold) - Fast MSA generation
-- [Boltz2](https://github.com/jwohlwend/boltz) - Protein structure prediction
-- [UniProt speclist.txt](https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/docs/speclist.txt) - Species code to TaxID mapping
+**Solution**: The converter includes a comprehensive species mapping. For rare species:
+1. Use explicit `OX=` field in A3M headers
+2. The converter will attempt online lookup if enabled
 
+### Large MSA Performance
+
+**Problem**: Conversion is slow for large MSAs
+
+**Solutions**:
+1. Limit pairs: `--max-pairs 1000`
+2. Use default (no `--include-unpaired`) to reduce rows
+3. Pre-filter A3M files to remove redundant sequences
+
+---
+
+## Summary
+
+The A3M to Multimer MSA converter enables seamless transition from ColabFold monomer searches to Boltz2 multimer predictions by:
+
+1. **Parsing** various A3M header formats
+2. **Pairing** sequences by organism (TaxID or UniRef ID)
+3. **Generating** per-chain CSVs with matching keys
+4. **Optionally including** unpaired sequences in block-diagonal format
+
+This provides Boltz2 with the co-evolutionary signal needed for accurate multimer structure prediction.

--- a/examples/nims/boltz-2/tests/test_a3m_to_csv_converter.py
+++ b/examples/nims/boltz-2/tests/test_a3m_to_csv_converter.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""
+Tests for A3M to CSV Multimer MSA Converter.
+
+Tests cover:
+1. A3M parsing (headers, sequences, various formats)
+2. Pairing strategies (greedy, complete)
+3. TaxID vs UniRef ID pairing
+4. CSV generation
+5. Block-diagonal unpaired sequences (new feature)
+"""
+
+import pytest
+from pathlib import Path
+from boltz2_client.a3m_to_csv_converter import (
+    A3MParser,
+    A3MMSA,
+    A3MSequence,
+    A3MToCSVConverter,
+    GreedyPairingStrategy,
+    CompletePairingStrategy,
+    TaxonomyPairingStrategy,
+    SpeciesMapper,
+    convert_a3m_to_multimer_csv,
+    create_paired_msa_per_chain,
+    ConversionResult,
+    SPECIES_TO_TAXID,
+)
+
+
+# Test data
+CHAIN_A_A3M = """>Query|-|Query
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+>UniRef100_A0A2N5EEG3	340	0.994
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+>UniRef100_UPI000755DEB5	340	0.994
+MKTVRQERLKSIVRILERSKDPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+>UniRef100_Q54321	320	0.95
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLG
+>UniRef100_B67890	315	0.90
+MKTVRQERLKSIVRILERSKEPVSGAQLAEDLSVSRQVIVQDIAYLRSLG
+"""
+
+CHAIN_B_A3M = """>Query|-|Query
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAPAD
+>UniRef100_A0A2N5EEG3	340	0.994
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAPAD
+>UniRef100_UPI000755DEB5	340	0.994
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAERPAD
+>UniRef100_X99999	300	0.85
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAE
+>UniRef100_B67890	315	0.90
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAPAD
+"""
+
+# A3M with TaxID annotations
+CHAIN_A_TAXID_A3M = """>Query|-|Query
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+>tr|A0A0B4J2F2|A0A0B4J2F2_HUMAN
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+>tr|P12345|P12345_MOUSE
+MKTVRQERLKSIVRILERSKDPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG
+>UniRef100_XYZ123 OX=7955
+MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLG
+"""
+
+CHAIN_B_TAXID_A3M = """>Query|-|Query
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAPAD
+>tr|Q99999|Q99999_HUMAN
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAPAD
+>tr|Q54321|Q54321_MOUSE
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAERPAD
+>UniRef100_ABC456 OX=7955
+MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAE
+"""
+
+
+class TestA3MParser:
+    """Tests for A3M file parsing."""
+    
+    def test_parse_basic(self):
+        """Test basic A3M parsing."""
+        msa = A3MParser.parse(CHAIN_A_A3M)
+        
+        assert len(msa.sequences) == 5
+        assert msa.sequences[0].is_query == True
+        
+    def test_parse_query_sequence(self):
+        """Test query sequence identification."""
+        msa = A3MParser.parse(CHAIN_A_A3M)
+        
+        query = msa.get_query()
+        assert query is not None
+        assert query.is_query == True
+        assert len(query.sequence) == 65  # Actual length of test sequence
+        
+    def test_parse_uniref_headers(self):
+        """Test parsing UniRef-style headers."""
+        msa = A3MParser.parse(CHAIN_A_A3M)
+        
+        # Skip query, check first UniRef entry
+        seq = msa.sequences[1]
+        assert seq.identifier == "UniRef100_A0A2N5EEG3"
+        assert seq.organism_id == "A0A2N5EEG3"
+        
+    def test_parse_uniprot_headers(self):
+        """Test parsing UniProt-style headers (tr|...|..._SPECIES)."""
+        a3m_content = """>Query
+MKTVRQERL
+>tr|A0A0B4J2F2|A0A0B4J2F2_HUMAN
+MKTVRQERL
+>sp|P04637|P53_HUMAN
+MKTVRQERL
+"""
+        msa = A3MParser.parse(a3m_content)
+        
+        assert len(msa.sequences) == 3
+        
+        # Check UniProt entry parsing
+        seq1 = msa.sequences[1]
+        assert seq1.identifier == "A0A0B4J2F2"
+        assert seq1.species == "HUMAN"
+        assert seq1.tax_id == "9606"  # Should map HUMAN -> 9606
+        
+    def test_parse_ox_field(self):
+        """Test parsing explicit OX= taxonomic ID."""
+        a3m_content = """>Query
+MKTVRQERL
+>UniRef100_ABC123 OX=9606 n=5
+MKTVRQERL
+"""
+        msa = A3MParser.parse(a3m_content)
+        
+        seq = msa.sequences[1]
+        assert seq.tax_id == "9606"
+        
+    def test_get_organism_ids(self):
+        """Test getting unique organism IDs."""
+        msa = A3MParser.parse(CHAIN_A_A3M)
+        
+        org_ids = msa.get_organism_ids()
+        assert len(org_ids) == 4  # 4 non-query sequences
+        assert "A0A2N5EEG3" in org_ids
+        assert "UPI000755DEB5" in org_ids
+        
+    def test_get_tax_ids(self):
+        """Test getting unique TaxIDs."""
+        msa = A3MParser.parse(CHAIN_A_TAXID_A3M)
+        
+        tax_ids = msa.get_tax_ids()
+        assert "9606" in tax_ids  # HUMAN
+        assert "10090" in tax_ids  # MOUSE
+        assert "7955" in tax_ids  # From OX= field
+
+
+class TestA3MSequence:
+    """Tests for A3MSequence header parsing."""
+    
+    def test_uniprot_format(self):
+        """Test UniProt format parsing."""
+        seq = A3MSequence(
+            header=">tr|A0A0B4J2F2|A0A0B4J2F2_HUMAN",
+            sequence="MKTVRQERL"
+        )
+        assert seq.identifier == "A0A0B4J2F2"
+        assert seq.species == "HUMAN"
+        assert seq.tax_id == "9606"
+        
+    def test_uniref_format(self):
+        """Test UniRef format parsing."""
+        seq = A3MSequence(
+            header=">UniRef100_A0A2N5EEG3	340	0.994",
+            sequence="MKTVRQERL"
+        )
+        assert seq.identifier == "UniRef100_A0A2N5EEG3"
+        assert seq.organism_id == "A0A2N5EEG3"
+        
+    def test_ox_field_parsing(self):
+        """Test OX= field extraction."""
+        seq = A3MSequence(
+            header=">UniRef100_ABC123 OX=9606 n=5 Tax=Homo sapiens",
+            sequence="MKTVRQERL"
+        )
+        assert seq.tax_id == "9606"
+        
+    def test_ncbi_format(self):
+        """Test NCBI format with [Species name]."""
+        seq = A3MSequence(
+            header=">gi|123|ref|NP_001.1| protein [Homo sapiens]",
+            sequence="MKTVRQERL"
+        )
+        assert seq.species == "Homo sapiens"
+        assert seq.tax_id == "9606"
+        
+
+class TestSpeciesMapper:
+    """Tests for species code to TaxID mapping."""
+    
+    def test_builtin_mapping(self):
+        """Test built-in species mapping."""
+        assert SpeciesMapper.get_tax_id("HUMAN") == "9606"
+        assert SpeciesMapper.get_tax_id("MOUSE") == "10090"
+        assert SpeciesMapper.get_tax_id("ECOLI") == "562"
+        assert SpeciesMapper.get_tax_id("YEAST") == "559292"
+        
+    def test_unknown_species(self):
+        """Test unknown species returns None."""
+        assert SpeciesMapper.get_tax_id("UNKNOWN_SPECIES_XYZ") is None
+        
+    def test_builtin_mapping_coverage(self):
+        """Test that built-in mapping has common organisms."""
+        assert "HUMAN" in SPECIES_TO_TAXID
+        assert "MOUSE" in SPECIES_TO_TAXID
+        assert "ECOLI" in SPECIES_TO_TAXID
+        assert "DROME" in SPECIES_TO_TAXID  # Drosophila
+        assert "ARATH" in SPECIES_TO_TAXID  # Arabidopsis
+
+
+class TestPairingStrategies:
+    """Tests for sequence pairing strategies."""
+    
+    def test_greedy_pairing_uniref(self):
+        """Test greedy pairing with UniRef IDs."""
+        msa_a = A3MParser.parse(CHAIN_A_A3M)
+        msa_b = A3MParser.parse(CHAIN_B_A3M)
+        
+        msa_a.chain_id = 'A'
+        msa_b.chain_id = 'B'
+        
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        pairs = strategy.find_pairs({'A': msa_a, 'B': msa_b})
+        
+        # Query + 3 common organisms (A0A2N5EEG3, UPI000755DEB5, B67890)
+        assert len(pairs) == 4
+        
+    def test_greedy_pairing_taxid(self):
+        """Test greedy pairing with TaxIDs."""
+        msa_a = A3MParser.parse(CHAIN_A_TAXID_A3M)
+        msa_b = A3MParser.parse(CHAIN_B_TAXID_A3M)
+        
+        msa_a.chain_id = 'A'
+        msa_b.chain_id = 'B'
+        
+        strategy = GreedyPairingStrategy(use_tax_id=True)
+        pairs = strategy.find_pairs({'A': msa_a, 'B': msa_b})
+        
+        # Query + 3 common TaxIDs (9606/HUMAN, 10090/MOUSE, 7955/zebrafish)
+        assert len(pairs) == 4
+        
+    def test_taxonomy_strategy(self):
+        """Test taxonomy-based pairing strategy."""
+        msa_a = A3MParser.parse(CHAIN_A_TAXID_A3M)
+        msa_b = A3MParser.parse(CHAIN_B_TAXID_A3M)
+        
+        msa_a.chain_id = 'A'
+        msa_b.chain_id = 'B'
+        
+        strategy = TaxonomyPairingStrategy(strategy="greedy")
+        pairs = strategy.find_pairs({'A': msa_a, 'B': msa_b})
+        
+        assert len(pairs) >= 1  # At least query
+
+
+class TestA3MToCSVConverter:
+    """Tests for the main converter class."""
+    
+    def test_basic_conversion_with_uniref(self):
+        """Test basic conversion with UniRef IDs (use_tax_id=False)."""
+        # Use UniRef-based pairing for test data without TaxIDs
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        converter = A3MToCSVConverter(pairing_strategy=strategy)
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_A3M, 'B': CHAIN_B_A3M}
+        )
+        
+        assert result.num_pairs == 4  # Query + 3 common organisms
+        assert len(result.chain_ids) == 2
+        assert 'A' in result.csv_per_chain
+        assert 'B' in result.csv_per_chain
+        
+    def test_basic_conversion_with_taxid(self):
+        """Test basic conversion with TaxID-based pairing."""
+        # Use TaxID-based pairing for data with TaxIDs
+        strategy = GreedyPairingStrategy(use_tax_id=True)
+        converter = A3MToCSVConverter(pairing_strategy=strategy)
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_TAXID_A3M, 'B': CHAIN_B_TAXID_A3M}
+        )
+        
+        # Query + 3 common TaxIDs (9606/HUMAN, 10090/MOUSE, 7955/zebrafish)
+        assert result.num_pairs == 4
+        
+    def test_csv_format(self):
+        """Test CSV output format."""
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        converter = A3MToCSVConverter(pairing_strategy=strategy)
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_A3M, 'B': CHAIN_B_A3M}
+        )
+        
+        # Check CSV header
+        assert result.csv_per_chain['A'].startswith('key,sequence')
+        assert result.csv_per_chain['B'].startswith('key,sequence')
+        
+        # Check that keys match across chains
+        lines_a = result.csv_per_chain['A'].split('\n')
+        lines_b = result.csv_per_chain['B'].split('\n')
+        
+        keys_a = [line.split(',')[0] for line in lines_a[1:] if line]
+        keys_b = [line.split(',')[0] for line in lines_b[1:] if line]
+        
+        assert keys_a == keys_b  # Keys should match
+        
+    def test_include_unpaired_false(self):
+        """Test that unpaired sequences are excluded by default."""
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        converter = A3MToCSVConverter(pairing_strategy=strategy, include_unpaired=False)
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_A3M, 'B': CHAIN_B_A3M}
+        )
+        
+        # Count rows (excluding header)
+        lines_a = result.csv_per_chain['A'].strip().split('\n')
+        assert len(lines_a) == 5  # header + 4 pairs (query + 3 common)
+        
+    def test_include_unpaired_true(self):
+        """Test that unpaired sequences are included in block-diagonal format."""
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        converter = A3MToCSVConverter(pairing_strategy=strategy, include_unpaired=True)
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_A3M, 'B': CHAIN_B_A3M}
+        )
+        
+        # Count rows (excluding header)
+        lines_a = result.csv_per_chain['A'].strip().split('\n')
+        
+        # Should have: header + 4 paired + unpaired from A (Q54321) + unpaired from B (X99999)
+        # Chain A has Q54321 that's not in B
+        # Chain B has X99999 that's not in A
+        assert len(lines_a) > 5  # More than just paired
+        
+    def test_unpaired_block_diagonal_format(self):
+        """Test that unpaired sequences use gaps for other chains."""
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        converter = A3MToCSVConverter(pairing_strategy=strategy, include_unpaired=True)
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_A3M, 'B': CHAIN_B_A3M}
+        )
+        
+        # Parse CSVs
+        lines_a = result.csv_per_chain['A'].strip().split('\n')
+        lines_b = result.csv_per_chain['B'].strip().split('\n')
+        
+        # Find rows where one chain has gaps
+        gap_rows_a = [line for line in lines_a[1:] if ',' in line and line.split(',')[1].startswith('-')]
+        gap_rows_b = [line for line in lines_b[1:] if ',' in line and line.split(',')[1].startswith('-')]
+        
+        # Chain A should have gap rows (for B's unpaired sequences)
+        # Chain B should have gap rows (for A's unpaired sequences)
+        # At least one chain should have gaps
+        assert len(gap_rows_a) > 0 or len(gap_rows_b) > 0
+        
+    def test_max_pairs_limit(self):
+        """Test max_pairs parameter."""
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        converter = A3MToCSVConverter(pairing_strategy=strategy, max_pairs=2)
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_A3M, 'B': CHAIN_B_A3M}
+        )
+        
+        assert result.num_pairs == 2
+        
+    def test_query_sequences_extracted(self):
+        """Test that query sequences are correctly extracted."""
+        converter = A3MToCSVConverter()
+        result = converter.convert_content(
+            a3m_contents={'A': CHAIN_A_A3M, 'B': CHAIN_B_A3M}
+        )
+        
+        assert 'A' in result.query_sequences
+        assert 'B' in result.query_sequences
+        assert len(result.query_sequences['A']) == 65  # Actual length
+        assert len(result.query_sequences['B']) == 63
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience functions."""
+    
+    def test_convert_a3m_to_multimer_csv(self, tmp_path):
+        """Test the main convenience function."""
+        # Create temp A3M files
+        chain_a_file = tmp_path / "chain_A.a3m"
+        chain_b_file = tmp_path / "chain_B.a3m"
+        chain_a_file.write_text(CHAIN_A_A3M)
+        chain_b_file.write_text(CHAIN_B_A3M)
+        
+        output_file = tmp_path / "paired.csv"
+        
+        result = convert_a3m_to_multimer_csv(
+            a3m_files={'A': chain_a_file, 'B': chain_b_file},
+            output_path=output_file
+        )
+        
+        assert result.num_pairs == 4
+        assert output_file.exists()
+        
+    def test_convert_with_include_unpaired(self, tmp_path):
+        """Test conversion with include_unpaired=True."""
+        chain_a_file = tmp_path / "chain_A.a3m"
+        chain_b_file = tmp_path / "chain_B.a3m"
+        chain_a_file.write_text(CHAIN_A_A3M)
+        chain_b_file.write_text(CHAIN_B_A3M)
+        
+        result = convert_a3m_to_multimer_csv(
+            a3m_files={'A': chain_a_file, 'B': chain_b_file},
+            include_unpaired=True
+        )
+        
+        # With unpaired, we should have more rows
+        lines = result.csv_per_chain['A'].strip().split('\n')
+        assert len(lines) > 5  # More than header + 4 paired
+        
+    def test_create_paired_msa_per_chain(self, tmp_path):
+        """Test creating MSA data structures for Boltz2."""
+        chain_a_file = tmp_path / "chain_A.a3m"
+        chain_b_file = tmp_path / "chain_B.a3m"
+        chain_a_file.write_text(CHAIN_A_A3M)
+        chain_b_file.write_text(CHAIN_B_A3M)
+        
+        result = convert_a3m_to_multimer_csv(
+            a3m_files={'A': chain_a_file, 'B': chain_b_file}
+        )
+        
+        msa_per_chain = create_paired_msa_per_chain(result)
+        
+        assert 'A' in msa_per_chain
+        assert 'B' in msa_per_chain
+        assert 'paired' in msa_per_chain['A']
+        assert 'csv' in msa_per_chain['A']['paired']
+
+
+class TestAutoDetection:
+    """Tests for auto-detection of pairing mode."""
+    
+    def test_auto_detect_taxid_mode(self, tmp_path):
+        """Test auto-detection when TaxIDs are present."""
+        chain_a_file = tmp_path / "chain_A.a3m"
+        chain_b_file = tmp_path / "chain_B.a3m"
+        chain_a_file.write_text(CHAIN_A_TAXID_A3M)
+        chain_b_file.write_text(CHAIN_B_TAXID_A3M)
+        
+        # With use_tax_id=None, should auto-detect
+        result = convert_a3m_to_multimer_csv(
+            a3m_files={'A': chain_a_file, 'B': chain_b_file},
+            use_tax_id=None  # Auto-detect
+        )
+        
+        # Should successfully create pairs
+        assert result.num_pairs >= 1
+        
+    def test_force_taxid_mode(self, tmp_path):
+        """Test forcing TaxID mode."""
+        chain_a_file = tmp_path / "chain_A.a3m"
+        chain_b_file = tmp_path / "chain_B.a3m"
+        chain_a_file.write_text(CHAIN_A_TAXID_A3M)
+        chain_b_file.write_text(CHAIN_B_TAXID_A3M)
+        
+        result = convert_a3m_to_multimer_csv(
+            a3m_files={'A': chain_a_file, 'B': chain_b_file},
+            use_tax_id=True
+        )
+        
+        assert result.num_pairs >= 1
+        
+    def test_force_uniref_mode(self, tmp_path):
+        """Test forcing UniRef mode."""
+        chain_a_file = tmp_path / "chain_A.a3m"
+        chain_b_file = tmp_path / "chain_B.a3m"
+        chain_a_file.write_text(CHAIN_A_A3M)
+        chain_b_file.write_text(CHAIN_B_A3M)
+        
+        result = convert_a3m_to_multimer_csv(
+            a3m_files={'A': chain_a_file, 'B': chain_b_file},
+            use_tax_id=False
+        )
+        
+        assert result.num_pairs == 4
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+    
+    def test_empty_a3m(self):
+        """Test handling of empty A3M content."""
+        converter = A3MToCSVConverter()
+        
+        empty_a3m = ""
+        msa = A3MParser.parse(empty_a3m)
+        assert len(msa.sequences) == 0
+        
+    def test_single_sequence_a3m(self):
+        """Test A3M with only query sequence."""
+        single_a3m = """>Query
+MKTVRQERL
+"""
+        msa = A3MParser.parse(single_a3m)
+        assert len(msa.sequences) == 1
+        
+    def test_no_common_organisms(self):
+        """Test when chains have no common organisms."""
+        chain_a = """>Query
+MKTVRQERL
+>UniRef100_OnlyInA
+MKTVRQERL
+"""
+        chain_b = """>Query
+MVTPEGNVS
+>UniRef100_OnlyInB
+MVTPEGNVS
+"""
+        converter = A3MToCSVConverter()
+        result = converter.convert_content(
+            a3m_contents={'A': chain_a, 'B': chain_b}
+        )
+        
+        # Should only have query pair
+        assert result.num_pairs == 1
+        
+    def test_no_common_with_include_unpaired(self):
+        """Test including unpaired when there are no common organisms."""
+        chain_a = """>Query
+MKTVRQERL
+>UniRef100_OnlyInA
+MKTVRQERL
+"""
+        chain_b = """>Query
+MVTPEGNVS
+>UniRef100_OnlyInB
+MVTPEGNVS
+"""
+        converter = A3MToCSVConverter(include_unpaired=True)
+        result = converter.convert_content(
+            a3m_contents={'A': chain_a, 'B': chain_b}
+        )
+        
+        # Should have query pair + 2 unpaired
+        lines_a = result.csv_per_chain['A'].strip().split('\n')
+        assert len(lines_a) == 4  # header + query + 2 unpaired
+        
+    def test_three_chains(self):
+        """Test with three chains."""
+        chain_a = """>Query
+MKTVRQERL
+>UniRef100_Common
+MKTVRQERL
+"""
+        chain_b = """>Query
+MVTPEGNVS
+>UniRef100_Common
+MVTPEGNVS
+"""
+        chain_c = """>Query
+MAAAAEEEE
+>UniRef100_Common
+MAAAAEEEE
+"""
+        # Use UniRef-based pairing for test data without TaxIDs
+        strategy = GreedyPairingStrategy(use_tax_id=False)
+        converter = A3MToCSVConverter(pairing_strategy=strategy)
+        result = converter.convert_content(
+            a3m_contents={'A': chain_a, 'B': chain_b, 'C': chain_c}
+        )
+        
+        assert len(result.chain_ids) == 3
+        assert result.num_pairs == 2  # Query + Common
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add include_unpaired parameter to A3MToCSVConverter and convert_a3m_to_multimer_csv
- Block-diagonal format includes unpaired sequences with gaps for other chains
- Add --include-unpaired CLI flag to convert-msa and multimer-msa commands
- Add comprehensive test suite (36 tests) for A3M to CSV converter
- Update documentation guide with new feature