### PR TITLE
feat: Boltz2 NIM v1.5 support with enhanced features (v0.4.0)

### DIFF
--- a/examples/nims/boltz-2/MULTI_ENDPOINT_GUIDE.md
+++ b/examples/nims/boltz-2/MULTI_ENDPOINT_GUIDE.md
@@ -90,10 +90,10 @@ endpoints = [
     ),
 ]
 
-# Create multi-endpoint client
+# Create multi-endpoint client (default strategy: LEAST_LOADED)
 multi_client = MultiEndpointClient(
     endpoints=endpoints,
-    strategy=LoadBalanceStrategy.LEAST_LOADED,
+    # strategy=LoadBalanceStrategy.LEAST_LOADED,  # This is the default
     health_check_interval=30.0,  # Check health every 30 seconds
 )
 
@@ -103,20 +103,20 @@ vs = VirtualScreening(client=multi_client)
 
 ### Running Multiple Local NIM Instances
 
-To run multiple Boltz-2 NIM instances on different ports:
+To run multiple Boltz-2 NIM v1.5 instances on different ports:
 
 ```bash
 # Terminal 1 - First instance on port 8000
-docker run --rm --gpus device=0 -p 8000:8000 \
-  nvcr.io/nim/mit/boltz-2:latest
+docker run --rm --gpus device=0 --shm-size=16G -p 8000:8000 \
+  -e NGC_API_KEY nvcr.io/nim/mit/boltz2:1.5.0
 
 # Terminal 2 - Second instance on port 8001  
-docker run --rm --gpus device=1 -p 8001:8000 \
-  nvcr.io/nim/mit/boltz-2:latest
+docker run --rm --gpus device=1 --shm-size=16G -p 8001:8000 \
+  -e NGC_API_KEY nvcr.io/nim/mit/boltz2:1.5.0
 
 # Terminal 3 - Third instance on port 8002
-docker run --rm --gpus device=2 -p 8002:8000 \
-  nvcr.io/nim/mit/boltz-2:latest
+docker run --rm --gpus device=2 --shm-size=16G -p 8002:8000 \
+  -e NGC_API_KEY nvcr.io/nim/mit/boltz2:1.5.0
 ```
 
 ## 🧬 **Complete Functionality Examples**
@@ -383,10 +383,11 @@ multi_client.print_status()
 
 ## Performance Tips
 
-1. **Use Least Loaded Strategy**: Generally provides best throughput
+1. **Least Loaded is Default**: The `LEAST_LOADED` strategy is now the default (generally provides best throughput)
 2. **Set Appropriate Weights**: Assign higher weights to more powerful servers
 3. **Monitor Health**: Adjust health check intervals based on your needs
 4. **Batch Size**: Consider using smaller batch sizes to distribute work better
+5. **v1.5 Limits**: Use up to `recycling_steps=10` and `diffusion_samples=25` for higher quality
 
 ## Deployment Patterns
 

--- a/examples/nims/boltz-2/PARAMETERS.md
+++ b/examples/nims/boltz-2/PARAMETERS.md
@@ -22,7 +22,7 @@ This document provides a comprehensive reference for all available Boltz-2 API p
 
 #### `polymers` (List[Polymer])
 - **Description**: List of polymers (DNA, RNA, or Protein) to predict
-- **Range**: 1-5 polymers
+- **Range**: 1-12 polymers (v1.5+), 1-5 (v1.3)
 - **Required**: Yes
 - **Example**:
 ```python
@@ -56,7 +56,7 @@ ligands = [
 
 ### `recycling_steps` (int)
 - **Description**: Number of recycling steps for iterative refinement
-- **Range**: 1-6
+- **Range**: 1-10 (v1.5+), 1-6 (v1.3)
 - **Default**: 3
 - **Effect**: Higher values improve accuracy but increase computation time
 - **Recommendations**:
@@ -76,7 +76,7 @@ ligands = [
 
 ### `diffusion_samples` (int)
 - **Description**: Number of independent diffusion samples
-- **Range**: 1-5
+- **Range**: 1-25 (v1.5+), 1-5 (v1.3)
 - **Default**: 1
 - **Effect**: Multiple samples provide diversity and ensemble predictions
 - **Usage**: Use >1 for uncertainty estimation or best-of-N selection
@@ -530,11 +530,11 @@ request = PredictionRequest(
 
 ### Speed vs Quality Trade-offs
 
-| Parameter | Fast | Balanced | High Quality |
-|-----------|------|----------|--------------|
-| recycling_steps | 1-2 | 3-4 | 5-6 |
+| Parameter | Fast | Balanced | High Quality (v1.5+) |
+|-----------|------|----------|----------------------|
+| recycling_steps | 1-2 | 3-4 | 6-10 |
 | sampling_steps | 10-30 | 50-100 | 200-1000 |
-| diffusion_samples | 1 | 1-2 | 3-5 |
+| diffusion_samples | 1 | 1-2 | 5-25 |
 | step_scale | 1.638 | 1.2-2.0 | 0.8-1.5 |
 
 ### Memory Usage
@@ -560,11 +560,11 @@ diffusion_samples=2
 step_scale=1.2
 ```
 
-#### High-Accuracy Research
+#### High-Accuracy Research (v1.5+)
 ```python
-recycling_steps=6
+recycling_steps=10      # Up to 10 in v1.5
 sampling_steps=500
-diffusion_samples=5
+diffusion_samples=25    # Up to 25 in v1.5
 step_scale=1.0
 ```
 
@@ -584,7 +584,7 @@ step_scale=1.0
 try:
     request = PredictionRequest(
         polymers=[],  # Empty list not allowed
-        recycling_steps=10  # Outside range 1-6
+        recycling_steps=15  # Outside range 1-10 (v1.5)
     )
 except ValidationError as e:
     print(f"Validation error: {e}")

--- a/examples/nims/boltz-2/README.md
+++ b/examples/nims/boltz-2/README.md
@@ -10,6 +10,7 @@ A comprehensive Python client for NVIDIA's Boltz-2 biomolecular structure predic
 
 ## 🚀 **Features**
 
+- ✅ **Boltz2 NIM v1.5 Support** - Compatible with the latest NVIDIA Boltz2 NIM
 - ✅ **Full API Coverage** - Complete Boltz-2 API support
 - ✅ **Async & Sync Clients** - Choose your preferred programming style
 - ✅ **Rich CLI Interface** - Beautiful command-line tools with progress bars
@@ -20,8 +21,11 @@ A comprehensive Python client for NVIDIA's Boltz-2 biomolecular structure predic
 - ✅ **Affinity Prediction** - Predict binding affinity (IC50) for protein-ligand complexes
 - ✅ **Virtual Screening** - High-level API for drug discovery campaigns
 - ✅ **MSA Search Integration** - GPU-accelerated MSA generation with NVIDIA MSA Search NIM
-- ✅ **A3M to Multimer MSA** - Convert ColabFold A3M files to paired multimer format (NEW)
-- ✅ **Multi-Endpoint Load Balancing** - Distribute predictions across multiple NIMs
+- ✅ **A3M to Multimer MSA** - Convert ColabFold A3M files to paired multimer format
+- ✅ **Multi-Endpoint Load Balancing** - Distribute predictions across multiple NIMs (default: least-loaded)
+- ✅ **PAE/PDE Matrix Output** - Full Predicted Aligned Error and Distance Error matrices
+- ✅ **PDB Output Format** - Export structures as PDB in addition to mmCIF
+- ✅ **Structural Templates** - Template-guided structure prediction
 - ✅ **Comprehensive Examples** - Ready-to-use code samples
 
 ## 📦 **Installation**
@@ -108,12 +112,19 @@ boltz2 msa-ligand "PROTEIN_SEQUENCE" --smiles "LIGAND_SMILES" --predict-affinity
 # Convert ColabFold A3M files to paired multimer CSV
 boltz2 convert-msa chain_A.a3m chain_B.a3m -c A,B -o paired.csv
 
-# One-command multimer prediction from A3M files (NEW)
+# One-command multimer prediction from A3M files
 boltz2 multimer-msa chain_A.a3m chain_B.a3m -c A,B -o complex.cif
 
-# Multi-endpoint multimer prediction
+# With PAE matrix output and PDB format
+boltz2 multimer-msa chain_A.a3m chain_B.a3m -c A,B -o complex.pdb \
+    --output-format pdb --write-full-pae --save-all
+
+# High-quality prediction with v1.5 limits (up to 10 recycling, 25 diffusion samples)
+boltz2 protein "MKTVRQ..." --recycling-steps 10 --diffusion-samples 25
+
+# Multi-endpoint multimer prediction (default: least-loaded balancing)
 boltz2 --multi-endpoint --base-url "http://gpu1:8000,http://gpu2:8000" \
-    multimer-msa chain_A.a3m chain_B.a3m -c A,B -o complex.cif
+    multimer-msa chain_A.a3m chain_B.a3m -c A,B -o complex.cif --save-all
 ```
 
 ### Affinity Prediction
@@ -238,11 +249,12 @@ boltz2 --multi-endpoint \
     multimer-msa chain_A.a3m chain_B.a3m -c A,B -o complex.cif --save-all
 ```
 
-**Output files with `--save-all --save-csv`:**
+**Output files with `--save-all --save-csv --write-full-pae`:**
 ```
 output/
-├── complex.cif              # 3D structure (mmCIF)
-├── complex.scores.json      # Confidence scores, pLDDT, pTM, metrics
+├── complex.cif              # 3D structure (mmCIF) or .pdb with --output-format pdb
+├── complex.scores.json      # Confidence scores, pLDDT, pTM, ipTM, metrics
+├── complex.pae.json         # PAE matrix (with --write-full-pae)
 ├── complex_chain_A.csv      # Paired MSA for chain A
 └── complex_chain_B.csv      # Paired MSA for chain B
 ```
@@ -297,21 +309,21 @@ result = quick_screen(
 print(result.get_top_hits(n=5))
 ```
 
-### Multi-Endpoint Virtual Screening (NEW)
+### Multi-Endpoint Virtual Screening
 
 Parallelize screening across multiple Boltz-2 NIM endpoints for better throughput:
 
 ```python
 from boltz2_client import MultiEndpointClient, LoadBalanceStrategy, VirtualScreening
 
-# Configure multiple endpoints
+# Configure multiple endpoints (default strategy: LEAST_LOADED)
 multi_client = MultiEndpointClient(
     endpoints=[
         "http://localhost:8000",
         "http://localhost:8001",
         "http://localhost:8002",
-    ],
-    strategy=LoadBalanceStrategy.LEAST_LOADED
+    ]
+    # strategy=LoadBalanceStrategy.LEAST_LOADED  # This is the default
 )
 
 # Use with virtual screening
@@ -407,10 +419,11 @@ chmod -R 777 $LOCAL_NIM_CACHE
 ```bash
 docker run -it \
     --runtime=nvidia \
+    --shm-size=16G \
     -p 8000:8000 \
     -e NGC_API_KEY \
     -v "$LOCAL_NIM_CACHE":/opt/nim/.cache \
-    nvcr.io/nim/mit/boltz2:1.0.0
+    nvcr.io/nim/mit/boltz2:1.5.0
 ```
 
 #### Option B: Use Specific GPU (e.g., GPU 0)
@@ -418,10 +431,11 @@ docker run -it \
 docker run -it \
     --runtime=nvidia \
     --gpus='"device=0"' \
+    --shm-size=16G \
     -p 8000:8000 \
     -e NGC_API_KEY \
     -v "$LOCAL_NIM_CACHE":/opt/nim/.cache \
-    nvcr.io/nim/mit/boltz2:1.0.0
+    nvcr.io/nim/mit/boltz2:1.5.0
 ```
 
 ### Step 5: Verify Installation
@@ -543,6 +557,66 @@ result = await client.predict_with_advanced_parameters(
     sampling_steps=200,
     diffusion_samples=1
 )
+```
+
+### Boltz2 NIM v1.5 Features
+
+The client supports all v1.5 parameters and limits:
+
+```python
+from boltz2_client import Boltz2Client, PredictionRequest, Polymer
+
+client = Boltz2Client(base_url="http://localhost:8000")
+
+# High-quality prediction with v1.5 limits
+request = PredictionRequest(
+    polymers=[Polymer(id="A", molecule_type="protein", sequence="MKTVRQ...")],
+    recycling_steps=10,      # Up to 10 (was 6 in v1.3)
+    diffusion_samples=25,    # Up to 25 (was 5 in v1.3)
+    write_full_pae=True,     # Output full PAE matrix
+    write_full_pde=True,     # Output full PDE matrix
+)
+
+result = await client.predict(request)
+
+# Access PAE/PDE matrices
+if result.pae:
+    print(f"PAE shape: {len(result.pae)}x{len(result.pae[0])}x{len(result.pae[0][0])}")
+```
+
+**v1.5 Parameter Limits:**
+| Parameter | v1.3 Limit | v1.5 Limit |
+|-----------|------------|------------|
+| `recycling_steps` | 1-6 | 1-10 |
+| `diffusion_samples` | 1-5 | 1-25 |
+| `polymers` | 5 | 12 |
+| `ligands` | 5 | 20 |
+
+### PAE/PDE Matrix Output
+
+```python
+from boltz2_client import save_pae_matrix, get_pae_summary
+
+# Save PAE matrix to file
+save_pae_matrix(result.pae, "output.pae.json")
+save_pae_matrix(result.pae, "output.pae.npy", format="npy")  # NumPy format
+
+# Get summary statistics
+summary = get_pae_summary(result.pae)
+print(f"Mean PAE: {summary['mean_pae']:.2f}")
+print(f"Quality: {summary['quality']}")  # Very High/High/Medium/Low
+```
+
+### PDB Output Format
+
+```python
+from boltz2_client import convert_cif_to_pdb
+
+# Convert mmCIF to PDB format
+convert_cif_to_pdb("structure.cif", "structure.pdb")
+
+# CLI: Use --output-format pdb
+# boltz2 protein "SEQUENCE" -o output.pdb --output-format pdb
 ```
 
 ### 🆕 Affinity Prediction

--- a/examples/nims/boltz-2/boltz2_client/__init__.py
+++ b/examples/nims/boltz-2/boltz2_client/__init__.py
@@ -26,7 +26,7 @@ Example:
     >>> print(f"Confidence: {result.confidence_scores[0]:.3f}")
 """
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 __author__ = "NVIDIA Corporation"
 __email__ = "bionemo-support@nvidia.com"
 
@@ -43,6 +43,8 @@ from .models import (
     AlignmentFormat,
     HealthStatus,
     ServiceMetadata,
+    StructuralTemplate,
+    Modification,
 )
 from .models_affinity import AffinityPrediction
 from .exceptions import (
@@ -81,6 +83,11 @@ from .a3m_to_csv_converter import (
     create_paired_msa_per_chain,
     save_prediction_outputs,
     get_prediction_summary,
+    save_pae_matrix,
+    save_pde_matrix,
+    get_pae_summary,
+    convert_cif_to_pdb,
+    convert_pdb_to_cif,
     ConversionResult,
     GreedyPairingStrategy,
     CompletePairingStrategy,
@@ -130,6 +137,8 @@ __all__ = [
     "HealthStatus",
     "ServiceMetadata",
     "AffinityPrediction",
+    "StructuralTemplate",
+    "Modification",
     
     # Exceptions
     "Boltz2Error",
@@ -167,6 +176,11 @@ __all__ = [
     "create_paired_msa_per_chain",
     "save_prediction_outputs",
     "get_prediction_summary",
+    "save_pae_matrix",
+    "save_pde_matrix",
+    "get_pae_summary",
+    "convert_cif_to_pdb",
+    "convert_pdb_to_cif",
     "ConversionResult",
     "GreedyPairingStrategy",
     "CompletePairingStrategy",

--- a/examples/nims/boltz-2/boltz2_client/a3m_to_csv_converter.py
+++ b/examples/nims/boltz-2/boltz2_client/a3m_to_csv_converter.py
@@ -23,7 +23,7 @@ Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 import re
 import csv
 import logging
-from typing import Dict, List, Optional, Tuple, Set, NamedTuple
+from typing import Dict, List, Optional, Tuple, Set, NamedTuple, Union
 from pathlib import Path
 from dataclasses import dataclass, field
 from collections import defaultdict
@@ -1735,4 +1735,278 @@ def get_prediction_summary(response) -> Dict:
         summary['prediction_time_seconds'] = response.metrics['total_time_seconds']
     
     return summary
+
+
+def save_pae_matrix(
+    pae: List[List[List[float]]],
+    output_path: Union[str, Path],
+    format: str = "json"
+) -> Path:
+    """
+    Save PAE (Predicted Aligned Error) matrix to file.
+    
+    Args:
+        pae: PAE matrix from PredictionResponse.pae
+             Shape: [num_models, num_residues, num_residues]
+        output_path: Path to save the file
+        format: Output format - "json" or "npy" (numpy)
+        
+    Returns:
+        Path to saved file
+        
+    Example:
+        >>> if response.pae:
+        ...     save_pae_matrix(response.pae, "structure.pae.json")
+    """
+    import json
+    
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    if format == "json":
+        with open(output_path, "w") as f:
+            json.dump({"pae": pae}, f, indent=2)
+    elif format == "npy":
+        try:
+            import numpy as np
+            np.save(output_path, np.array(pae))
+        except ImportError:
+            raise ImportError("numpy is required for .npy format. Install with: pip install numpy")
+    else:
+        raise ValueError(f"Unsupported format: {format}. Use 'json' or 'npy'")
+    
+    return output_path
+
+
+def save_pde_matrix(
+    pde: List[List[List[float]]],
+    output_path: Union[str, Path],
+    format: str = "json"
+) -> Path:
+    """
+    Save PDE (Predicted Distance Error) matrix to file.
+    
+    Args:
+        pde: PDE matrix from PredictionResponse.pde
+             Shape: [num_models, num_residues, num_residues]
+        output_path: Path to save the file
+        format: Output format - "json" or "npy" (numpy)
+        
+    Returns:
+        Path to saved file
+        
+    Example:
+        >>> if response.pde:
+        ...     save_pde_matrix(response.pde, "structure.pde.json")
+    """
+    import json
+    
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    if format == "json":
+        with open(output_path, "w") as f:
+            json.dump({"pde": pde}, f, indent=2)
+    elif format == "npy":
+        try:
+            import numpy as np
+            np.save(output_path, np.array(pde))
+        except ImportError:
+            raise ImportError("numpy is required for .npy format. Install with: pip install numpy")
+    else:
+        raise ValueError(f"Unsupported format: {format}. Use 'json' or 'npy'")
+    
+    return output_path
+
+
+def get_pae_summary(pae: List[List[List[float]]]) -> Dict:
+    """
+    Get summary statistics for PAE matrix.
+    
+    Args:
+        pae: PAE matrix from PredictionResponse.pae
+        
+    Returns:
+        Dictionary with shape, mean, min, max values
+        
+    Example:
+        >>> summary = get_pae_summary(response.pae)
+        >>> print(f"Mean PAE: {summary['mean']:.2f} Å")
+    """
+    if not pae:
+        return {}
+    
+    # Flatten to get statistics
+    all_values = []
+    for model_pae in pae:
+        for row in model_pae:
+            all_values.extend(row)
+    
+    return {
+        "shape": f"{len(pae)}x{len(pae[0])}x{len(pae[0][0])}",
+        "num_models": len(pae),
+        "num_residues": len(pae[0]),
+        "mean": sum(all_values) / len(all_values),
+        "min": min(all_values),
+        "max": max(all_values),
+    }
+
+
+def convert_cif_to_pdb(
+    cif_input: Union[str, Path],
+    pdb_output: Union[str, Path],
+    structure_id: str = "PRED"
+) -> Path:
+    """
+    Convert mmCIF file to PDB format.
+    
+    Uses gemmi (preferred, faster) or BioPython as fallback.
+    
+    Args:
+        cif_input: Path to input CIF file or CIF content as string
+        pdb_output: Path for output PDB file
+        structure_id: Structure ID to use in PDB file (default: "PRED")
+        
+    Returns:
+        Path to the saved PDB file
+        
+    Example:
+        >>> convert_cif_to_pdb("structure.cif", "structure.pdb")
+        >>> # Or from string content
+        >>> convert_cif_to_pdb(cif_content, "structure.pdb")
+        
+    Note:
+        Requires either gemmi or BioPython to be installed:
+        - pip install gemmi  (recommended, faster)
+        - pip install biopython
+    """
+    import tempfile
+    
+    pdb_output = Path(pdb_output)
+    pdb_output.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Check if input is a file path or string content
+    cif_path = Path(cif_input) if isinstance(cif_input, (str, Path)) and Path(cif_input).exists() else None
+    
+    # If input is string content, write to temp file
+    if cif_path is None:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.cif', delete=False) as f:
+            f.write(str(cif_input))
+            cif_path = Path(f.name)
+        cleanup_temp = True
+    else:
+        cif_path = Path(cif_input)
+        cleanup_temp = False
+    
+    try:
+        # Try gemmi first (faster)
+        try:
+            import gemmi
+            structure = gemmi.read_structure(str(cif_path))
+            structure.write_pdb(str(pdb_output))
+            return pdb_output
+        except ImportError:
+            pass
+        
+        # Fallback to BioPython
+        try:
+            from Bio.PDB import MMCIFParser, PDBIO
+            import warnings
+            
+            # Suppress BioPython warnings about incomplete structures
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                
+                parser = MMCIFParser(QUIET=True)
+                structure = parser.get_structure(structure_id, str(cif_path))
+                
+                io = PDBIO()
+                io.set_structure(structure)
+                io.save(str(pdb_output))
+                
+            return pdb_output
+        except ImportError:
+            raise ImportError(
+                "CIF to PDB conversion requires either gemmi or BioPython. "
+                "Install with: pip install gemmi  (recommended) or pip install biopython"
+            )
+    finally:
+        # Clean up temp file if created
+        if cleanup_temp and cif_path.exists():
+            cif_path.unlink()
+
+
+def convert_pdb_to_cif(
+    pdb_input: Union[str, Path],
+    cif_output: Union[str, Path],
+    structure_id: str = "PRED"
+) -> Path:
+    """
+    Convert PDB file to mmCIF format.
+    
+    Uses gemmi (preferred, faster) or BioPython as fallback.
+    
+    Args:
+        pdb_input: Path to input PDB file or PDB content as string
+        cif_output: Path for output CIF file
+        structure_id: Structure ID to use (default: "PRED")
+        
+    Returns:
+        Path to the saved CIF file
+        
+    Example:
+        >>> convert_pdb_to_cif("structure.pdb", "structure.cif")
+    """
+    import tempfile
+    
+    cif_output = Path(cif_output)
+    cif_output.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Check if input is a file path or string content
+    pdb_path = Path(pdb_input) if isinstance(pdb_input, (str, Path)) and Path(pdb_input).exists() else None
+    
+    # If input is string content, write to temp file
+    if pdb_path is None:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False) as f:
+            f.write(str(pdb_input))
+            pdb_path = Path(f.name)
+        cleanup_temp = True
+    else:
+        pdb_path = Path(pdb_input)
+        cleanup_temp = False
+    
+    try:
+        # Try gemmi first (faster)
+        try:
+            import gemmi
+            structure = gemmi.read_structure(str(pdb_path))
+            structure.write_minimal_cif(str(cif_output))
+            return cif_output
+        except ImportError:
+            pass
+        
+        # Fallback to BioPython
+        try:
+            from Bio.PDB import PDBParser, MMCIFIO
+            import warnings
+            
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                
+                parser = PDBParser(QUIET=True)
+                structure = parser.get_structure(structure_id, str(pdb_path))
+                
+                io = MMCIFIO()
+                io.set_structure(structure)
+                io.save(str(cif_output))
+                
+            return cif_output
+        except ImportError:
+            raise ImportError(
+                "PDB to CIF conversion requires either gemmi or BioPython. "
+                "Install with: pip install gemmi  (recommended) or pip install biopython"
+            )
+    finally:
+        if cleanup_temp and pdb_path.exists():
+            pdb_path.unlink()
 

--- a/examples/nims/boltz-2/boltz2_client/cli.py
+++ b/examples/nims/boltz-2/boltz2_client/cli.py
@@ -260,22 +260,29 @@ def metadata(ctx):
 @cli.command()
 @click.argument('sequence')
 @click.option('--polymer-id', default='A', help='Polymer identifier (default: A)')
-@click.option('--recycling-steps', default=3, type=click.IntRange(1, 6), 
-              help='Number of recycling steps (1-6, default: 3)')
+@click.option('--recycling-steps', default=3, type=click.IntRange(1, 10), 
+              help='Number of recycling steps (1-10, default: 3)')
 @click.option('--sampling-steps', default=50, type=click.IntRange(10, 1000),
               help='Number of sampling steps (10-1000, default: 50)')
-@click.option('--diffusion-samples', default=1, type=click.IntRange(1, 5),
-              help='Number of diffusion samples (1-5, default: 1)')
+@click.option('--diffusion-samples', default=1, type=click.IntRange(1, 25),
+              help='Number of diffusion samples (1-25, default: 1)')
 @click.option('--step-scale', default=1.638, type=click.FloatRange(0.5, 5.0),
               help='Step scale for diffusion sampling (0.5-5.0, default: 1.638)')
 @click.option('--msa-file', multiple=True, type=(str, click.Choice(['sto', 'a3m', 'csv', 'fasta'])),
               help='MSA file and format (can be specified multiple times)')
 @click.option('--output-dir', type=click.Path(), default='.', help='Directory to save output files (structure_0.cif, prediction_metadata.json). Default: current directory')
 @click.option('--no-save', is_flag=True, help='Do not save structure files')
+@click.option('--write-full-pae', is_flag=True, default=False,
+              help='Output full PAE (Predicted Aligned Error) matrix as JSON')
+@click.option('--write-full-pde', is_flag=True, default=False,
+              help='Output full PDE (Predicted Distance Error) matrix as JSON')
+@click.option('--output-format', type=click.Choice(['cif', 'pdb']), default='cif',
+              help='Output structure format: cif (default) or pdb')
 @click.pass_context
 def protein(ctx, sequence: str, polymer_id: str, recycling_steps: int, sampling_steps: int,
            diffusion_samples: int, step_scale: float, msa_file: List[Tuple[str, str]], 
-           output_dir: str, no_save: bool):
+           output_dir: str, no_save: bool, write_full_pae: bool, write_full_pde: bool,
+           output_format: str):
     """
     Predict protein structure with optional MSA guidance.
     
@@ -301,9 +308,48 @@ def protein(ctx, sequence: str, polymer_id: str, recycling_steps: int, sampling_
             print_info(f"Predicting structure for protein sequence (length: {len(sequence)})")
             print_info(f"Parameters: recycling_steps={recycling_steps}, sampling_steps={sampling_steps}")
             print_info(f"            diffusion_samples={diffusion_samples}, step_scale={step_scale}")
+            if write_full_pae:
+                print_info(f"            write_full_pae=True")
+            if write_full_pde:
+                print_info(f"            write_full_pde=True")
             
             if msa_files:
                 print_info(f"Using {len(msa_files)} MSA file(s)")
+            
+            # Build MSA if files provided
+            msa_dict = None
+            if msa_files:
+                msa_dict = {}
+                for i, (file_path, format_type) in enumerate(msa_files):
+                    with open(file_path, "r") as fh:
+                        content = fh.read()
+                    msa_record = AlignmentFileRecord(
+                        alignment=content,
+                        format=format_type,
+                        rank=i
+                    )
+                    db_name = f"msa_{i}" if len(msa_files) > 1 else "default"
+                    if db_name not in msa_dict:
+                        msa_dict[db_name] = {}
+                    msa_dict[db_name][format_type] = msa_record
+            
+            # Create polymer and request
+            polymer = Polymer(
+                id=polymer_id,
+                molecule_type="protein",
+                sequence=sequence,
+                msa=msa_dict
+            )
+            
+            request = PredictionRequest(
+                polymers=[polymer],
+                recycling_steps=recycling_steps,
+                sampling_steps=sampling_steps,
+                diffusion_samples=diffusion_samples,
+                step_scale=step_scale,
+                write_full_pae=write_full_pae,
+                write_full_pde=write_full_pde
+            )
             
             with Progress(
                 SpinnerColumn(),
@@ -316,14 +362,8 @@ def protein(ctx, sequence: str, polymer_id: str, recycling_steps: int, sampling_
                 def progress_callback(message: str):
                     progress.update(task, description=message)
                 
-                result = await client.predict_protein_structure(
-                    sequence=sequence,
-                    polymer_id=polymer_id,
-                    recycling_steps=recycling_steps,
-                    sampling_steps=sampling_steps,
-                    diffusion_samples=diffusion_samples,
-                    step_scale=step_scale,
-                    msa_files=msa_files if msa_files else None,
+                result = await client.predict(
+                    request,
                     save_structures=not no_save,
                     output_dir=Path(output_dir),
                     progress_callback=progress_callback
@@ -341,6 +381,32 @@ def protein(ctx, sequence: str, polymer_id: str, recycling_steps: int, sampling_
             
             if not no_save:
                 print_info(f"Structures saved to: {output_dir}")
+                
+                # Convert to PDB if requested
+                if output_format == 'pdb':
+                    from .a3m_to_csv_converter import convert_cif_to_pdb
+                    for i in range(len(result.structures)):
+                        cif_path = Path(output_dir) / f"structure_{i}.cif"
+                        if cif_path.exists():
+                            pdb_path = Path(output_dir) / f"structure_{i}.pdb"
+                            convert_cif_to_pdb(cif_path, pdb_path)
+                            print_info(f"Converted to PDB: {pdb_path}")
+            
+            # Save PAE matrix if requested and available
+            if write_full_pae and result.pae:
+                import json
+                pae_path = Path(output_dir) / f"structure_{polymer_id}.pae.json"
+                pae_path.write_text(json.dumps({'pae': result.pae}, indent=2))
+                pae_shape = f"{len(result.pae)}x{len(result.pae[0])}x{len(result.pae[0][0])}"
+                print_info(f"PAE matrix saved to: {pae_path} (shape: {pae_shape})")
+            
+            # Save PDE matrix if requested and available
+            if write_full_pde and result.pde:
+                import json
+                pde_path = Path(output_dir) / f"structure_{polymer_id}.pde.json"
+                pde_path.write_text(json.dumps({'pde': result.pde}, indent=2))
+                pde_shape = f"{len(result.pde)}x{len(result.pde[0])}x{len(result.pde[0][0])}"
+                print_info(f"PDE matrix saved to: {pde_path} (shape: {pde_shape})")
             
         except Exception as e:
             print_error(f"Prediction failed: {e}")
@@ -1679,12 +1745,19 @@ def convert_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
               help='Number of diffusion sampling steps (default: 200)')
 @click.option('--diffusion-samples', type=int, default=1,
               help='Number of diffusion samples/structures (default: 1)')
+@click.option('--write-full-pae', is_flag=True, default=False,
+              help='Output full PAE (Predicted Aligned Error) matrix')
+@click.option('--write-full-pde', is_flag=True, default=False,
+              help='Output full PDE (Predicted Distance Error) matrix')
+@click.option('--output-format', type=click.Choice(['cif', 'pdb']), default='cif',
+              help='Output structure format: cif (default) or pdb')
 @click.pass_context
 def multimer_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str, 
                          output: Optional[str], save_csv: bool, save_all: bool,
                          max_pairs: Optional[int], pairing_mode: str, include_unpaired: bool,
                          recycling_steps: int, sampling_steps: int, 
-                         diffusion_samples: int):
+                         diffusion_samples: int, write_full_pae: bool, write_full_pde: bool,
+                         output_format: str):
     """
     Predict multimer structure from ColabFold A3M monomer MSA files.
     
@@ -1823,7 +1896,9 @@ def multimer_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
             polymers=polymers,
             recycling_steps=recycling_steps,
             sampling_steps=sampling_steps,
-            diffusion_samples=diffusion_samples
+            diffusion_samples=diffusion_samples,
+            write_full_pae=write_full_pae,
+            write_full_pde=write_full_pde
         )
         
         # Step 5: Get client (supports multi-endpoint mode)
@@ -1858,19 +1933,48 @@ def multimer_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
             
             output_path = Path(output)
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(cif_content)
+            
+            # Handle output format
+            if output_format == 'pdb':
+                # Save as CIF first, then convert
+                cif_temp_path = output_path.with_suffix('.cif')
+                cif_temp_path.write_text(cif_content)
+                
+                # Convert to PDB
+                from .a3m_to_csv_converter import convert_cif_to_pdb
+                pdb_path = output_path.with_suffix('.pdb')
+                convert_cif_to_pdb(cif_temp_path, pdb_path)
+                print_success(f"Structure saved to: {pdb_path}")
+                
+                # Also keep the CIF if save_all is enabled, otherwise remove
+                if not save_all:
+                    cif_temp_path.unlink()
+                else:
+                    print_info(f"CIF also saved: {cif_temp_path}")
+            else:
+                output_path.write_text(cif_content)
+                print_success(f"Structure saved to: {output_path}")
             
             atom_count = cif_content.count('ATOM ')
-            print_success(f"Structure saved to: {output_path}")
             print_info(f"Total atoms: {atom_count}")
             
             # Save additional structures if multiple samples
             if len(response.structures) > 1:
+                from .a3m_to_csv_converter import convert_cif_to_pdb
                 for i, struct in enumerate(response.structures[1:], start=2):
-                    extra_path = output_path.with_stem(f"{output_path.stem}_{i}")
                     cif = struct.structure if hasattr(struct, 'structure') else str(struct)
-                    extra_path.write_text(cif)
-                    print_info(f"Additional structure: {extra_path}")
+                    if output_format == 'pdb':
+                        extra_cif = output_path.with_stem(f"{output_path.stem}_{i}").with_suffix('.cif')
+                        extra_cif.write_text(cif)
+                        extra_pdb = output_path.with_stem(f"{output_path.stem}_{i}").with_suffix('.pdb')
+                        convert_cif_to_pdb(extra_cif, extra_pdb)
+                        print_info(f"Additional structure: {extra_pdb}")
+                        if not save_all:
+                            extra_cif.unlink()
+                    else:
+                        extra_path = output_path.with_stem(f"{output_path.stem}_{i}")
+                        extra_path.write_text(cif)
+                        print_info(f"Additional structure: {extra_path}")
             
             # Save all outputs if requested
             if save_all:
@@ -1909,6 +2013,20 @@ def multimer_msa_command(ctx, a3m_files: Tuple[str, ...], chain_ids: str,
                     print_info(f"Interface pTM: {response.iptm_scores[0]:.4f}")
                 if response.ptm_scores:
                     print_info(f"pTM: {response.ptm_scores[0]:.4f}")
+            
+            # Save PAE matrix if available
+            if write_full_pae and response.pae:
+                pae_path = output_path.with_suffix('.pae.json')
+                pae_path.write_text(json.dumps({'pae': response.pae}, indent=2))
+                pae_shape = f"{len(response.pae)}x{len(response.pae[0])}x{len(response.pae[0][0])}"
+                print_info(f"PAE matrix saved to: {pae_path} (shape: {pae_shape})")
+            
+            # Save PDE matrix if available
+            if write_full_pde and response.pde:
+                pde_path = output_path.with_suffix('.pde.json')
+                pde_path.write_text(json.dumps({'pde': response.pde}, indent=2))
+                pde_shape = f"{len(response.pde)}x{len(response.pde[0])}x{len(response.pde[0][0])}"
+                print_info(f"PDE matrix saved to: {pde_path} (shape: {pde_shape})")
         else:
             print_error("No structures returned from prediction")
             raise click.Abort()

--- a/examples/nims/boltz-2/boltz2_client/client.py
+++ b/examples/nims/boltz-2/boltz2_client/client.py
@@ -29,7 +29,7 @@ from .models import (
     PredictionRequest, PredictionResponse, HealthStatus, ServiceMetadata,
     Polymer, Ligand, PocketConstraint, BondConstraint, Atom, AlignmentFileRecord,
     StructureData, PredictionJob, PolymerType, AlignmentFormat, ConstraintType,
-    YAMLConfig, YAMLConfigType
+    YAMLConfig, YAMLConfigType, StructuralTemplate, Modification
 )
 from .exceptions import (
     Boltz2ClientError, Boltz2APIError, Boltz2ValidationError, 
@@ -581,6 +581,91 @@ class Boltz2Client:
         
         return await self.predict(request, **kwargs)
 
+    async def predict_with_templates(
+        self,
+        sequence: str,
+        templates: List[Union[str, Path, StructuralTemplate]],
+        polymer_id: str = "A",
+        template_format: str = "cif",
+        recycling_steps: int = 3,
+        sampling_steps: int = 50,
+        diffusion_samples: int = 1,
+        step_scale: float = 1.638,
+        msa: Optional[Dict[str, Dict[str, AlignmentFileRecord]]] = None,
+        **kwargs
+    ) -> PredictionResponse:
+        """
+        Predict protein structure using structural templates for guidance.
+        
+        Structural templates can improve prediction accuracy by providing
+        structural information from homologous proteins.
+        
+        Args:
+            sequence: Protein sequence
+            templates: List of templates - can be file paths (str/Path) or StructuralTemplate objects
+            polymer_id: Polymer identifier
+            template_format: Format of template files ("cif" or "pdb") - used when templates are file paths
+            recycling_steps: Number of recycling steps (1-10)
+            sampling_steps: Number of sampling steps (10-1000)
+            diffusion_samples: Number of diffusion samples (1-25)
+            step_scale: Step scale for diffusion (0.5-5.0)
+            msa: Pre-constructed MSA dictionary
+            **kwargs: Additional parameters for predict()
+            
+        Returns:
+            Prediction response
+            
+        Example:
+            >>> result = await client.predict_with_templates(
+            ...     sequence="MKTVRQERLKS...",
+            ...     templates=["template1.cif", "template2.pdb"],
+            ...     template_format="cif"
+            ... )
+        """
+        # Process templates
+        structural_templates = []
+        for i, template in enumerate(templates):
+            if isinstance(template, StructuralTemplate):
+                structural_templates.append(template)
+            else:
+                # Load from file
+                template_path = Path(template)
+                if not template_path.exists():
+                    raise FileNotFoundError(f"Template file not found: {template_path}")
+                
+                content = template_path.read_text()
+                # Determine format from extension or use provided format
+                fmt = template_path.suffix.lower().lstrip('.')
+                if fmt not in ('cif', 'pdb'):
+                    fmt = template_format
+                
+                structural_templates.append(StructuralTemplate(
+                    structure=content,
+                    format=fmt,
+                    name=template_path.stem
+                ))
+        
+        if len(structural_templates) > 4:
+            raise Boltz2ValidationError("Maximum 4 structural templates allowed")
+        
+        polymer = Polymer(
+            id=polymer_id,
+            molecule_type="protein",
+            sequence=sequence,
+            msa=msa,
+            structural_templates=structural_templates
+        )
+        
+        request = PredictionRequest(
+            polymers=[polymer],
+            recycling_steps=recycling_steps,
+            sampling_steps=sampling_steps,
+            diffusion_samples=diffusion_samples,
+            step_scale=step_scale
+        )
+        
+        return await self.predict(request, **kwargs)
+
     async def predict_with_advanced_parameters(
         self,
         polymers: List[Polymer],
@@ -592,21 +677,25 @@ class Boltz2Client:
         step_scale: float = 1.638,
         without_potentials: bool = False,
         concatenate_msas: bool = False,
+        write_full_pae: bool = False,
+        write_full_pde: bool = False,
         **kwargs
     ) -> PredictionResponse:
         """
         Predict structure with full control over all advanced parameters.
         
         Args:
-            polymers: List of polymers (proteins, DNA, RNA)
-            ligands: Optional list of ligands
+            polymers: List of polymers (proteins, DNA, RNA) - max 12
+            ligands: Optional list of ligands - max 20
             constraints: Optional list of constraints
-            recycling_steps: Number of recycling steps (1-6)
+            recycling_steps: Number of recycling steps (1-10)
             sampling_steps: Number of sampling steps (10-1000)
-            diffusion_samples: Number of diffusion samples (1-5)
+            diffusion_samples: Number of diffusion samples (1-25)
             step_scale: Step scale for diffusion sampling (0.5-5.0)
             without_potentials: Whether to run without potentials
             concatenate_msas: Whether to concatenate MSAs
+            write_full_pae: Whether to return full PAE matrix in response
+            write_full_pde: Whether to return full PDE matrix in response
             **kwargs: Additional parameters for predict()
             
         Returns:
@@ -621,7 +710,9 @@ class Boltz2Client:
             diffusion_samples=diffusion_samples,
             step_scale=step_scale,
             without_potentials=without_potentials,
-            concatenate_msas=concatenate_msas
+            concatenate_msas=concatenate_msas,
+            write_full_pae=write_full_pae,
+            write_full_pde=write_full_pde
         )
         
         return await self.predict(request, **kwargs)
@@ -1315,6 +1406,10 @@ class Boltz2SyncClient:
     def predict_with_advanced_parameters(self, **kwargs) -> PredictionResponse:
         """Make prediction with full parameter control."""
         return asyncio.run(self._async_client.predict_with_advanced_parameters(**kwargs))
+    
+    def predict_with_templates(self, **kwargs) -> PredictionResponse:
+        """Predict protein structure using structural templates for guidance."""
+        return asyncio.run(self._async_client.predict_with_templates(**kwargs))
     
     def configure_msa_search(
         self,

--- a/examples/nims/boltz-2/boltz2_client/models.py
+++ b/examples/nims/boltz-2/boltz2_client/models.py
@@ -19,17 +19,23 @@ from .models_affinity import AffinityPrediction
 
 
 class Modification(BaseModel):
-    """Represents a molecular modification."""
-    type: str = Field(..., description="Type of modification")
-    position: int = Field(..., description="Position of modification")
-    details: Optional[Dict[str, Any]] = Field(None, description="Additional modification details")
+    """Represents a chemical modification to a polymer chain."""
+    ccd: str = Field(..., description="The Chemical Component Dictionary (CCD) ID of the modification (1-5 uppercase letters/numbers)")
+    position: int = Field(..., gt=0, description="The 1-based index of the residue to modify")
+    
+    @validator('ccd')
+    def validate_ccd(cls, v):
+        """Validate CCD code format."""
+        if not re.match(r'^[A-Z0-9]{1,5}$', v):
+            raise ValueError("CCD code must be 1-5 uppercase letters/numbers")
+        return v
 
 
 class AlignmentFileRecord(BaseModel):
     """Represents a single alignment file record."""
     alignment: str = Field(..., description="Raw alignment file content as string")
     format: Literal["sto", "a3m", "csv", "fasta"] = Field(..., description="Alignment file format")
-    rank: int = Field(-1, description="Integer rank to define ordering of alignments")
+    rank: Optional[int] = Field(-1, description="Integer rank to define ordering of alignments")
     
     @validator('alignment')
     def validate_alignment_content(cls, v):
@@ -39,15 +45,42 @@ class AlignmentFileRecord(BaseModel):
         return v
 
 
+class StructuralTemplate(BaseModel):
+    """A structural template to guide protein structure prediction."""
+    structure: str = Field(..., min_length=1, description="The template structure content in CIF or PDB format")
+    format: Literal["cif", "pdb"] = Field("cif", description="Format of the structure (cif or pdb)")
+    name: Optional[str] = Field(None, description="Optional name for the template (max 64 chars, alphanumeric with -_)")
+    chain_id: Optional[str] = Field(None, description="Optional chain ID to use from the template structure (1-4 alphanumeric)")
+    
+    @validator('name')
+    def validate_name(cls, v):
+        """Validate template name format."""
+        if v is not None:
+            if len(v) > 64:
+                raise ValueError("Template name must be 64 characters or less")
+            if not re.match(r'^[A-Za-z0-9_-]+$', v):
+                raise ValueError("Template name must contain only alphanumeric characters, underscores, and hyphens")
+        return v
+    
+    @validator('chain_id')
+    def validate_chain_id(cls, v):
+        """Validate chain ID format."""
+        if v is not None:
+            if not re.match(r'^[A-Za-z0-9]{1,4}$', v):
+                raise ValueError("Chain ID must be 1-4 alphanumeric characters")
+        return v
+
+
 class Polymer(BaseModel):
     """Represents a polymer (protein, DNA, or RNA) in the prediction request."""
     
-    id: str = Field(..., description="Unique identifier for the polymer (A-Z or 4 alphanumeric chars)")
+    id: Optional[str] = Field(None, description="Unique identifier for the polymer (1-4 alphanumeric chars)")
     molecule_type: Literal["protein", "dna", "rna"] = Field(..., description="Type of molecule")
-    sequence: str = Field(..., description="Sequence string")
-    cyclic: bool = Field(False, description="Whether the polymer is cyclic")
-    modifications: List[Modification] = Field(default_factory=list, description="List of modifications")
+    sequence: str = Field(..., max_length=4096, description="Sequence string (max 4096 characters)")
+    cyclic: Optional[bool] = Field(False, description="Whether the polymer is cyclic")
+    modifications: Optional[List[Modification]] = Field(default_factory=list, description="List of modifications")
     msa: Optional[Dict[str, Dict[str, AlignmentFileRecord]]] = Field(None, description="A Dictionary [database_name -> [format -> AlignmentFileRecord]] containing alignments")
+    structural_templates: Optional[List[StructuralTemplate]] = Field(None, description="Structural templates to guide prediction (max 4, protein only)")
     
     @validator('sequence')
     def validate_sequence(cls, v, values):
@@ -77,13 +110,23 @@ class Polymer(BaseModel):
     
     @validator('id')
     def validate_id(cls, v):
-        """Validate polymer ID format (single letter A-Z or 4 alphanumeric chars)."""
-        if re.match(r'^[A-Z]$', v):
-            return v  # Single letter A-Z
-        elif re.match(r'^[A-Za-z0-9]{4}$', v):
-            return v  # 4 alphanumeric characters
-        else:
-            raise ValueError("Polymer ID must be either a single letter (A-Z) or 4 alphanumeric characters")
+        """Validate polymer ID format (1-4 alphanumeric characters)."""
+        if v is not None:
+            if not re.match(r'^[A-Za-z0-9]{1,4}$', v):
+                raise ValueError("Polymer ID must be 1-4 alphanumeric characters")
+        return v
+    
+    @validator('structural_templates')
+    def validate_structural_templates(cls, v, values):
+        """Validate structural templates."""
+        if v is not None:
+            if len(v) > 4:
+                raise ValueError("Maximum 4 structural templates allowed")
+            # Only allowed for proteins
+            molecule_type = values.get('molecule_type')
+            if molecule_type and molecule_type != "protein":
+                raise ValueError("Structural templates are only allowed for protein molecules")
+        return v
 
 
 class Ligand(BaseModel):
@@ -112,9 +155,9 @@ class Ligand(BaseModel):
         if v is not None:
             if not v.strip():
                 raise ValueError("CCD code cannot be empty")
-            # CCD codes are typically 3-4 character alphanumeric codes
-            if not re.match(r'^[A-Za-z0-9]{2,4}$', v.strip()):
-                raise ValueError("CCD code must be 2-4 alphanumeric characters")
+            # CCD codes are 1-5 uppercase letters/numbers
+            if not re.match(r'^[A-Z0-9]{1,5}$', v.strip().upper()):
+                raise ValueError("CCD code must be 1-5 uppercase letters/numbers")
             return v.strip().upper()
         return v
     
@@ -182,10 +225,10 @@ class PredictionRequest(BaseModel):
     """Complete prediction request model with all available Boltz-2 parameters."""
     
     # Required parameters
-    polymers: List[Polymer] = Field(..., description="List of polymers (DNA, RNA, or Protein) - max 5, min 1")
+    polymers: List[Polymer] = Field(..., description="List of polymers (DNA, RNA, or Protein) - max 12, min 1")
     
     # Optional molecular components
-    ligands: Optional[List[Ligand]] = Field(None, description="List of ligands - max 5, min 0")
+    ligands: Optional[List[Ligand]] = Field(None, description="List of ligands - max 20, min 0")
     
     # Constraints
     constraints: Optional[List[Union[PocketConstraint, BondConstraint]]] = Field(
@@ -194,16 +237,16 @@ class PredictionRequest(BaseModel):
     
     # Diffusion and sampling parameters
     recycling_steps: Optional[int] = Field(
-        3, ge=1, le=6, 
-        description="The number of recycling steps to use for prediction (1-6, default: 3)"
+        3, ge=1, le=10, 
+        description="The number of recycling steps to use for prediction (1-10, default: 3)"
     )
     sampling_steps: Optional[int] = Field(
         50, ge=10, le=1000,
         description="The number of sampling steps to use for prediction (10-1000, default: 50)"
     )
     diffusion_samples: Optional[int] = Field(
-        1, ge=1, le=5,
-        description="The number of diffusion samples to use for prediction (1-5, default: 1)"
+        1, ge=1, le=25,
+        description="The number of diffusion samples to use for prediction (1-25, default: 1)"
     )
     step_scale: Optional[float] = Field(
         1.638, ge=0.5, le=5.0,
@@ -238,11 +281,21 @@ class PredictionRequest(BaseModel):
         description="Whether to add Molecular Weight correction to the affinity prediction (default: False)"
     )
     
+    # PAE/PDE output parameters (v1.5+)
+    write_full_pae: Optional[bool] = Field(
+        False,
+        description="Whether to save the full PAE (Predicted Aligned Error) matrix in the response (default: False)"
+    )
+    write_full_pde: Optional[bool] = Field(
+        False,
+        description="Whether to save the full PDE (Predicted Distance Error) matrix in the response (default: False)"
+    )
+    
     @validator('polymers')
     def validate_polymers_count(cls, v):
         """Validate polymer count."""
-        if len(v) > 5:
-            raise ValueError("Maximum 5 polymers allowed")
+        if len(v) > 12:
+            raise ValueError("Maximum 12 polymers allowed")
         if len(v) == 0:
             raise ValueError("At least 1 polymer required")
         return v
@@ -251,8 +304,8 @@ class PredictionRequest(BaseModel):
     def validate_ligands_count(cls, v):
         """Validate ligand count and affinity prediction constraints."""
         if v is not None:
-            if len(v) > 5:
-                raise ValueError("Maximum 5 ligands allowed")
+            if len(v) > 20:
+                raise ValueError("Maximum 20 ligands allowed")
             
             # Check that only one ligand has predict_affinity=True
             affinity_ligands = [lig for lig in v if getattr(lig, 'predict_affinity', False)]
@@ -305,6 +358,16 @@ class PredictionResponse(BaseModel):
     complex_ipde_scores: Optional[List[float]] = Field(None, description="Average PDE score when aggregating at interfaces")
     chains_ptm_scores: Optional[List[float]] = Field(None, description="Predicted TM score within each chain")
     pair_chains_iptm_scores: Optional[List[Dict[str, Any]]] = Field(None, description="Predicted TM score between each pair of chains")
+    
+    # Full error matrices (v1.5+)
+    pae: Optional[List[List[List[float]]]] = Field(
+        None, 
+        description="Full PAE (Predicted Aligned Error) matrix. Shape: [num_models, num_residues, num_residues]"
+    )
+    pde: Optional[List[List[List[float]]]] = Field(
+        None, 
+        description="Full PDE (Predicted Distance Error) matrix. Shape: [num_models, num_residues, num_residues]"
+    )
     
     @validator('structures')
     def validate_structures(cls, v):

--- a/examples/nims/boltz-2/boltz2_client/multi_endpoint_client.py
+++ b/examples/nims/boltz-2/boltz2_client/multi_endpoint_client.py
@@ -65,7 +65,7 @@ class MultiEndpointClient:
     def __init__(
         self,
         endpoints: List[Union[EndpointConfig, Dict[str, Any], str]],
-        strategy: LoadBalanceStrategy = LoadBalanceStrategy.ROUND_ROBIN,
+        strategy: LoadBalanceStrategy = LoadBalanceStrategy.LEAST_LOADED,
         health_check_interval: float = 60.0,
         timeout: float = 300.0,
         max_retries: int = 3,

--- a/examples/nims/boltz-2/tests/test_real_endpoints.py
+++ b/examples/nims/boltz-2/tests/test_real_endpoints.py
@@ -19,11 +19,12 @@ from boltz2_client import (
 )
 
 # Real endpoint configuration
+# Example endpoints (replace with your actual Boltz2 NIM endpoints)
 REAL_ENDPOINTS = [
-    "http://10.185.105.21:8000",
-    "http://10.185.105.21:8001", 
-    "http://10.185.105.21:8002",
-    "http://10.185.105.21:8003"
+    "http://198.51.100.10:8000",
+    "http://198.51.100.10:8001", 
+    "http://198.51.100.10:8002",
+    "http://198.51.100.10:8003"
 ]
 
 # Test data


### PR DESCRIPTION
## Summary

- Add Boltz2 NIM v1.5 compatibility with updated parameter limits
- Change default load balancing strategy to LEAST_LOADED for better throughput
- Add PAE/PDE matrix output support (`write_full_pae`, `write_full_pde`)
- Add PDB output format conversion (`--output-format pdb`)
- Increase parameter limits: recycling (1-10), diffusion (1-25), polymers (1-12), ligands (1-20)
- Add structural templates support for template-guided prediction
- Add helper functions: `save_pae_matrix`, `save_pde_matrix`, `get_pae_summary`
- Add CIF to PDB conversion utilities (`convert_cif_to_pdb`, `convert_pdb_to_cif`)
- Update Docker examples to use `boltz2:1.5.0` with `--shm-size=16G`
- Replace real IPs with RFC 5737 documentation IPs in examples
- Update documentation and parameter guides for v1.5

## Test plan

- [x] Tested multi-endpoint predictions with 2 endpoints (localhost:8010, remote:8010)
- [x] Verified PAE matrix output with `--write-full-pae` flag
- [x] Tested PDB output format with `--output-format pdb`
- [x] Validated `recycling_steps=10` and `diffusion_samples=25` work correctly
- [x] Published to PyPI as v0.4.0