### PR TITLE
boltz2-python-client v0.5.2.post1 - clean-install fix (lazy-import pandas)

### DIFF
--- a/examples/nims/boltz-2/CHANGELOG.md
+++ b/examples/nims/boltz-2/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2.post1] - 2026-02-24
+
+PEP 440 post-release patch on top of `0.5.2`. **No public API changes**;
+fixes a long-standing packaging defect that has been present since
+`0.5.0` (and was carried into `0.5.2` unchanged). Users on a clean
+environment should upgrade to `0.5.2.post1`; users who already have
+`pandas` installed will see no behavior difference.
+
+### Fixed — packaging
+- **`import boltz2_client` now works on a clean install.** Previously
+  `boltz2_client/virtual_screening.py` did `import pandas as pd` at
+  module top, but `pandas` is only declared in the `[dev]` extra (not a
+  runtime dependency), so any clean `pip install boltz2-python-client`
+  followed by `import boltz2_client` raised
+  `ModuleNotFoundError: No module named 'pandas'`. The pandas import is
+  now deferred into the four methods that actually need it
+  (`CompoundLibrary.from_csv`, `VirtualScreeningResult.to_dataframe`,
+  `VirtualScreeningResult.get_top_hits`,
+  `VirtualScreeningResult.get_statistics_by_group`); calling any of those
+  methods still requires pandas, but importing the package, the CLI,
+  and every other code path no longer does. Callers who use the virtual
+  screening DataFrame helpers should install with
+  `pip install "boltz2-python-client[dev]"` or add `pandas` to their
+  own environment.
+- A `from __future__ import annotations` was added to
+  `virtual_screening.py` so the `pd.DataFrame` return-type annotations
+  on those methods are evaluated lazily and do not require `pandas` at
+  import time. Static type checkers and IDEs continue to resolve the
+  annotations via a `TYPE_CHECKING` block.
+
 ## [0.5.2] - 2026-02-24
 
 ### Fixed — `MultiEndpointClient` reliability

--- a/examples/nims/boltz-2/boltz2_client/__init__.py
+++ b/examples/nims/boltz-2/boltz2_client/__init__.py
@@ -26,7 +26,7 @@ Example:
     >>> print(f"Confidence: {result.confidence_scores[0]:.3f}")
 """
 
-__version__ = "0.5.2"
+__version__ = "0.5.2.post1"
 __author__ = "NVIDIA Corporation"
 __email__ = "bionemo-support@nvidia.com"
 

--- a/examples/nims/boltz-2/boltz2_client/virtual_screening.py
+++ b/examples/nims/boltz-2/boltz2_client/virtual_screening.py
@@ -9,14 +9,26 @@ Provides high-level APIs for virtual screening campaigns with
 automatic parallelization, result analysis, and visualization.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Union, Any, Tuple, Callable
+from typing import TYPE_CHECKING, Dict, List, Optional, Union, Any, Tuple, Callable
 from concurrent.futures import ThreadPoolExecutor
-import pandas as pd
+
+if TYPE_CHECKING:
+    # ``pandas`` is an optional dependency that is only required by the
+    # CSV-loading and DataFrame-result helpers on this module. The module
+    # used to ``import pandas as pd`` at the top, which made the entire
+    # ``boltz2_client`` package un-importable on a clean install (pandas is
+    # a ``[dev]`` extra, not a runtime dep). The runtime import is now
+    # deferred into the methods that actually need it; this block only
+    # exists so static type checkers and IDEs can still resolve the
+    # ``pd.DataFrame`` annotations on those methods.
+    import pandas as pd
 
 from .client import Boltz2Client, Boltz2SyncClient
 from .models import Polymer, Ligand, PredictionRequest, Contact, PocketConstraint
@@ -45,6 +57,8 @@ class CompoundLibrary:
                  smiles_col: str = "smiles",
                  ccd_col: Optional[str] = None) -> "CompoundLibrary":
         """Load compound library from CSV file."""
+        import pandas as pd
+
         df = pd.read_csv(csv_path)
         compounds = []
         
@@ -134,8 +148,10 @@ class VirtualScreeningResult:
             return 0.0
         return len(self.successful_results) / len(self.results)
     
-    def to_dataframe(self) -> pd.DataFrame:
+    def to_dataframe(self) -> "pd.DataFrame":
         """Convert results to pandas DataFrame."""
+        import pandas as pd
+
         return pd.DataFrame(self.successful_results)
     
     def save_results(self, output_dir: Union[str, Path], 
@@ -189,16 +205,20 @@ class VirtualScreeningResult:
         
         return saved_files
     
-    def get_top_hits(self, n: int = 10, by: str = "predicted_pic50") -> pd.DataFrame:
+    def get_top_hits(self, n: int = 10, by: str = "predicted_pic50") -> "pd.DataFrame":
         """Get top N compounds by specified metric."""
+        import pandas as pd
+
         df = self.to_dataframe()
         if df.empty or by not in df.columns:
             return pd.DataFrame()
         
         return df.nlargest(n, by)
     
-    def get_statistics_by_group(self, group_by: str = "compound_type") -> pd.DataFrame:
+    def get_statistics_by_group(self, group_by: str = "compound_type") -> "pd.DataFrame":
         """Get statistics grouped by a metadata field."""
+        import pandas as pd
+
         df = self.to_dataframe()
         if df.empty or group_by not in df.columns:
             return pd.DataFrame()


### PR DESCRIPTION
PEP 440 post-release patch on top of [#34 (`v0.5.2`)](https://github.com/NVIDIA/digital-biology-examples/pull/34). Tagged on gitlab-master as `v0.5.2.post1`. **No public API changes**; fixes a long-standing packaging defect.

## TL;DR

Three files, +56/-6. Defers an `import pandas as pd` from module top into the four methods that actually use it, so `pip install boltz2-python-client` followed by `import boltz2_client` works on a clean env. `pandas` is **not** a runtime dependency (it's `[dev]`-only) — that's the root cause.

## Why

Caught during TestPyPI clean-install validation of `v0.5.2`. The bug actually existed in `0.5.0` and `0.5.1` already published on PyPI:

```
$ python3 -m venv /tmp/cleanenv
$ /tmp/cleanenv/bin/pip install boltz2-python-client==0.5.2
$ /tmp/cleanenv/bin/python -c "import boltz2_client"
Traceback (most recent call last):
  ...
  File ".../boltz2_client/virtual_screening.py", line 19, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```

The CLI (including the `boltz2 --version` flag added in `v0.5.2`) was equally unreachable on a clean install. We never noticed because almost everyone has `pandas` pre-installed in their data-science env.

## What changed

### `boltz2_client/virtual_screening.py`
- Removed module-top `import pandas as pd`.
- Added `from __future__ import annotations` so the `pd.DataFrame` return-type annotations on the affected methods are evaluated lazily and do not require `pandas` at import time.
- Added a `TYPE_CHECKING: import pandas as pd` block so static type checkers and IDEs can still resolve those annotations.
- Inserted `import pandas as pd` inside the **four** methods that actually use pandas:
  - `CompoundLibrary.from_csv`
  - `VirtualScreeningResult.to_dataframe`
  - `VirtualScreeningResult.get_top_hits`
  - `VirtualScreeningResult.get_statistics_by_group`

Calling any of those methods still requires pandas (unchanged); importing the package, running the CLI, and every other code path no longer does.

### `boltz2_client/__init__.py`
- `__version__` 0.5.2 -> 0.5.2.post1.

### `CHANGELOG.md`
- New `[0.5.2.post1] - 2026-02-24` entry placed above `[0.5.2]` documenting the packaging fix and rationale.

## Verification

- [x] `134/134` unit tests pass on the post1 commit (no regression from the lazy-import refactor).
- [x] `twine check` PASSED for both wheel and sdist of `0.5.2.post1`.
- [x] PEP 625-compliant filenames: `boltz2_python_client-0.5.2.post1-py3-none-any.whl` and `boltz2_python_client-0.5.2.post1.tar.gz`.
- [x] Diff in this PR is byte-for-byte identical to the gitlab-master `v0.5.2..v0.5.2.post1` patch (modulo the `examples/nims/boltz-2/` prefix). Verified by automated comparison.
- [x] **End-to-end clean-install verification**:
  ```
  python3 -m venv /tmp/cleanenv
  /tmp/cleanenv/bin/pip install boltz2_python_client-0.5.2.post1-py3-none-any.whl
  # pandas is NOT installed
  /tmp/cleanenv/bin/python -c "import boltz2_client; print(boltz2_client.__version__)"
  # -> 0.5.2.post1
  /tmp/cleanenv/bin/boltz2 --version
  # -> boltz2 0.5.2.post1
  ```
  All three of these previously raised `ModuleNotFoundError`.

## Test plan

```bash
git checkout boltz2-v0.5.2.post1
cd examples/nims/boltz-2
pip install -e .
boltz2 --version          # -> "boltz2 0.5.2.post1"
pytest tests -q --ignore=tests/test_live_endpoints.py
# expect: 134 passed
```

To reproduce the clean-install fix:

```bash
python3 -m venv /tmp/cleanenv
/tmp/cleanenv/bin/pip install ./examples/nims/boltz-2  # NO [dev]
/tmp/cleanenv/bin/python -c "import boltz2_client; print(boltz2_client.__version__)"
# Before this PR: ModuleNotFoundError: No module named 'pandas'
# After  this PR: 0.5.2.post1
```

## Note on PyPI plan

Once this PR is merged, `0.5.2.post1` will be uploaded to **TestPyPI first** (clean-install validated) and then the **same bytes** to **PyPI**. `pip install boltz2-python-client` will resolve to `0.5.2.post1` for users on `pip>=20.3`. The `0.5.2` slot on TestPyPI is permanently sealed with the broken artifact (PyPI's policy); the `0.5.2` slot on PyPI will remain unused.

Made with [Cursor](https://cursor.com)