### PR TITLE
Square Mol* viewers + document A100/H100/L40S support (L40S OOM caveat)

### DIFF
--- a/examples/resources/bionemo-protein-binder-design-launchable/Complexa_Binder_Design.ipynb
+++ b/examples/resources/bionemo-protein-binder-design-launchable/Complexa_Binder_Design.ipynb
@@ -14,7 +14,7 @@
     "design** campaign with **NVIDIA Proteina-Complexa** — a generative model that **co-designs the\n",
     "binder sequence and full-atom structure together** with reward-guided search — and then\n",
     "**independently validates** each binder by refolding the complex with **Boltz-2** and ranking on\n",
-    "interface confidence. It is tuned to finish in **well under an hour** on a single **A100 80 GB**.\n",
+    "interface confidence. It is tuned to finish in **well under an hour** on a single **A100 / H100 / L40S** GPU.\n",
     "\n",
     "> Sibling workflow: `protein-binder-design/` uses **RFdiffusion + ProteinMPNN**. This one uses\n",
     "> **Proteina-Complexa** (no separate inverse-folding step)."
@@ -110,6 +110,11 @@
     "GPUs like L40S). The co-fold cost scales with `N_ASSESS × DIFFUSION_SAMPLES × SAMPLING_STEPS`, so\n",
     "**dial those down for speed** or up for quality. `OPENHACKATHON_DEMO_MODE=0` uses the max\n",
     "(96 / 64 / 8 / 100). Enable the apo stability check with `PBD_APO=1`.\n",
+    "\n",
+    "**GPU.** Runs on **A100 / H100 / L40S**. On the 48 GB **L40S** (vs 80 GB A100/H100), very large\n",
+    "co-folding jobs — big complexes, high `PBD_DIFFUSION_SAMPLES`, or the AF2-reward path — can hit\n",
+    "**CUDA out-of-memory (OOM)**. If that happens, reduce `PBD_N_ASSESS` / `PBD_DIFFUSION_SAMPLES` (or\n",
+    "use a smaller binder/target).\n",
     "\n",
     "**Responsible use:** de novo binder design is dual-use — legitimate research/therapeutic intent only."
    ]
@@ -242,12 +247,14 @@
    "source": [
     "# Mol* view of the target with hotspots highlighted (red)\n",
     "from ipymolstar import PDBeMolstar\n",
+    "from ipywidgets import Layout\n",
     "color = [{\"struct_asym_id\": target_chain_hint, \"color\": \"#9ecae1\"}]\n",
     "for r in hotspot_resnums:\n",
     "    color.append({\"struct_asym_id\": target_chain_hint, \"residue_number\": int(r), \"color\": \"#e53935\"})\n",
     "tv = PDBeMolstar(custom_data={\"data\": pdb_text, \"format\": \"pdb\", \"binary\": False},\n",
     "                 hide_water=True, hide_controls_icon=True, hide_expand_icon=True,\n",
-    "                 hide_settings_icon=True, hide_animation_icon=True)\n",
+    "                 hide_settings_icon=True, hide_animation_icon=True,\n",
+    "                 layout=Layout(width=\"600px\", height=\"600px\"))  # square viewer\n",
     "tv.color_data = {\"data\": color, \"nonSelectedColor\": None}\n",
     "tv"
    ]
@@ -512,9 +519,11 @@
     "      \"holo complex:\", str(raw_json) if cif_text else \"not found\")\n",
     "if cif_text:\n",
     "    from ipymolstar import PDBeMolstar\n",
+    "    from ipywidgets import Layout\n",
     "    mol = PDBeMolstar(custom_data={\"data\": cif_text, \"format\": \"cif\", \"binary\": False},\n",
     "                      hide_water=True, hide_controls_icon=True, hide_expand_icon=True,\n",
-    "                      hide_settings_icon=True, hide_animation_icon=True)\n",
+    "                      hide_settings_icon=True, hide_animation_icon=True,\n",
+    "                      layout=Layout(width=\"600px\", height=\"600px\"))  # square viewer\n",
     "    # target chain A gray, designed binder chain B orange, conditioned hotspots red\n",
     "    cdata = [{\"struct_asym_id\": \"A\", \"color\": \"#cfd8dc\"},\n",
     "             {\"struct_asym_id\": \"B\", \"color\": \"#ff8c00\"}]\n",

--- a/examples/resources/bionemo-protein-binder-design-launchable/README.md
+++ b/examples/resources/bionemo-protein-binder-design-launchable/README.md
@@ -11,7 +11,7 @@ limitations under the License.
 # De Novo Protein Binder Design — Brev Launchable (Proteina-Complexa + Boltz-2)
 
 A self-contained **Brev Launchable** that runs an end-to-end de novo **protein binder design**
-campaign on a single **A100 80 GB** in **well under an hour**:
+campaign on a single **A100 / H100 / L40S** GPU in **well under an hour**:
 
 - **Generation — [NVIDIA Proteina-Complexa](https://github.com/NVIDIA-Digital-Bio/Proteina-Complexa):**
   co-designs the binder **sequence + full-atom structure together**. The default generates a broad
@@ -44,7 +44,7 @@ PD-L1, IL-17A, TNFα, VEGFA, HER2, …).
 
 ## Deploy on Brev (Console wizard)
 
-You need an **A100 80 GB** and an **`NGC_API_KEY`** (`nvapi-…`) for the local Boltz-2 NIM
+You need an **A100 / H100 (80 GB) or L40S (48 GB)** GPU and an **`NGC_API_KEY`** (`nvapi-…`) for the local Boltz-2 NIM
 (Proteina-Complexa + AF2 weights are public). The Brev **Console wizard** is the way to create a
 shareable Launchable (the CLI manages instances, not Launchables).
 
@@ -60,7 +60,7 @@ shareable Launchable (the CLI manages instances, not Launchables).
 3. **Jupyter / networking:** choose **No** to Brev's built-in Jupyter, then add a **secure link named
    `jupyter` on port `8888`** — `setup.sh` serves the widget-capable JupyterLab there (Brev's stock
    Jupyter can't render the Mol\* widgets). Optionally expose `8000` to reach Boltz-2 directly.
-4. **Compute:** 1× **A100 80 GB**, **~1 TB disk**.
+4. **Compute:** 1× **A100 / H100 (80 GB) or L40S (48 GB)**, **~1 TB disk**.
 5. **Review:** name it, set access (link / org / community), **Create Launchable** → shareable link + badge.
 
 See the [Brev Launchables docs](https://docs.nvidia.com/brev/concepts/launchables).
@@ -91,6 +91,10 @@ configuration from environment variables (with sensible defaults):
 
 > Co-fold cost scales with `N_ASSESS × DIFFUSION_SAMPLES × SAMPLING_STEPS` — dial down for speed, up
 > for quality (demo config runs ~20–40 min; longer on smaller GPUs like L40S).
+>
+> **L40S (48 GB) note:** vs A100/H100 (80 GB), very large co-folding jobs — big complexes, high
+> `PBD_DIFFUSION_SAMPLES`, or the AF2-reward path — may hit **CUDA OOM**; reduce `PBD_N_ASSESS` /
+> `PBD_DIFFUSION_SAMPLES` (or binder/target size) if so.
 
 **Strategy — generate broad, rank by Boltz-2.** The default generates a large pool fast (no AF2) and
 ranks it by **Boltz-2 co-folding ipTM**, surfacing the **top-K**. Boltz-2's co-folding is stochastic,


### PR DESCRIPTION
## Summary
- **Square Mol\*:** the embedded `ipymolstar` views were wide rectangles; now sized square (`layout` width == height).
- **GPU support docs:** the workflow runs on **A100 / H100 / L40S** (confirmed on L40S, cc 8.9) — docs previously said only A100. Added a caveat that on the **48 GB L40S** (vs 80 GB A100/H100) very large co-folding jobs (big complexes, high `PBD_DIFFUSION_SAMPLES`, or the AF2-reward path) can hit **CUDA OOM**; reduce `PBD_N_ASSESS` / `PBD_DIFFUSION_SAMPLES`.

## Test plan
- [x] notebook cells compile
- [ ] Mol* views render square; L40S deploy notes accurate