### PR TITLE
Switch binder-design default target to PD-L1 (more designable than the RBD)

### DIFF
--- a/examples/resources/bionemo-protein-binder-design-launchable/Complexa_Binder_Design.ipynb
+++ b/examples/resources/bionemo-protein-binder-design-launchable/Complexa_Binder_Design.ipynb
@@ -45,16 +45,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Target: SARS-CoV-2 spike RBD (therapeutic relevance)\n",
+    "## 2. Target: PD-L1 (cancer immunotherapy)\n",
     "\n",
-    "We design binders against the **Receptor-Binding Domain (RBD)** of the SARS-CoV-2 spike (registered\n",
-    "Complexa target **`30_SC2RBD`**, PDB `6M0J`, target span `E333-526`, conditioned hotspots\n",
-    "`E485, E489, E494, E500, E505`, binder length 80–120 aa).\n",
+    "We design binders against **PD-L1** (Programmed death-ligand 1 / CD274) — registered Complexa target\n",
+    "**`32_PDL1_ALPHA`**, PDB `5O45`, target span `A17-132`, conditioned hotspots `A56, A115, A123`,\n",
+    "binder length 50–120 aa.\n",
     "\n",
-    "The RBD grabs the human receptor **ACE2** to enter cells, so a binder that covers this interface\n",
-    "**blocks viral entry** (neutralizing) — the basis of antibody and de novo-minibinder therapeutics\n",
-    "and diagnostics. Swap `TARGET` below for any of the 44 registered targets (`complexa target list`)\n",
-    "— e.g. PD-L1, IL-17A, TNFα, VEGFA.\n",
+    "Tumors display PD-L1, which engages **PD-1** on T cells to switch them off (an immune *checkpoint*),\n",
+    "letting the tumor evade the immune system. A binder that covers PD-L1's PD-1-binding face **blocks\n",
+    "that checkpoint** and re-activates anti-tumor T cells — the mechanism of approved checkpoint-inhibitor\n",
+    "drugs (atezolizumab, durvalumab, avelumab). PD-L1 is a well-behaved, highly *designable* target.\n",
+    "Swap `TARGET` below for any registered target (`complexa target list`) — e.g. IL-7Rα (`31_IL7RA`),\n",
+    "TrkA (`33_TrkA`), VEGF-A (`36_VEGFA`), or the SARS-CoV-2 RBD (`30_SC2RBD`).\n",
     "\n",
     "> Educational example; verify epitopes against the literature before a real campaign."
    ]
@@ -67,8 +69,8 @@
     "\n",
     "```mermaid\n",
     "flowchart LR\n",
-    "    T[\"Target RBD + hotspots\n",
-    "(30_SC2RBD)\"] --> G[\"Proteina-Complexa\n",
+    "    T[\"Target PD-L1 + hotspots\n",
+    "(32_PDL1_ALPHA)\"] --> G[\"Proteina-Complexa\n",
     "co-design seq+structure\n",
     "BROAD pool, fast (no AF2)\"]\n",
     "    G --> H[\"Boltz-2 holo co-fold\n",
@@ -139,7 +141,7 @@
     "\n",
     "# --- campaign config ---\n",
     "DEMO = os.environ.get(\"OPENHACKATHON_DEMO_MODE\", \"1\") != \"0\"\n",
-    "TARGET       = os.environ.get(\"PBD_TARGET\", \"30_SC2RBD\")\n",
+    "TARGET       = os.environ.get(\"PBD_TARGET\", \"32_PDL1_ALPHA\")\n",
     "# Strategy: generate a BROAD pool fast (no AF2), then let Boltz-2 co-folding score + rank them.\n",
     "ALGORITHM    = os.environ.get(\"PBD_ALGORITHM\", \"single-pass\")    # broad sampling (no reward search)\n",
     "AF2_REWARD   = os.environ.get(\"PBD_AF2_REWARD\", \"0\") != \"0\"      # default OFF: no AF2 (Boltz-2 is the judge)\n",
@@ -206,7 +208,7 @@
    "source": [
     "## 5. Stage 1 — target and hotspots\n",
     "\n",
-    "Read the registered target (span, hotspots, binder length), fetch the RBD structure, and show the\n",
+    "Read the registered target (span, hotspots, binder length), fetch the PD-L1 structure, and show the\n",
     "conditioned hotspot patch with **Mol\\***."
    ]
   },
@@ -223,7 +225,7 @@
     "        if name in line and \":\" in line:\n",
     "            return line.split(\":\", 1)[1].strip()\n",
     "    return \"\"\n",
-    "pdb_id = (_field(\"pdb_id\") or \"6m0j\").lower()\n",
+    "pdb_id = (_field(\"pdb_id\") or \"5o45\").lower()\n",
     "target_span = _field(\"target_input\")           # e.g. E333-526\n",
     "import ast\n",
     "try:\n",
@@ -388,9 +390,10 @@
     "**top-K binders**. The pass/fail gate here **excludes ipSAE** (it's unavailable on Boltz-2's PAE and\n",
     "reads 0) — it checks ipTM ≥ 0.65, complex & binder pLDDT ≥ 0.70, and hotspot contact ≥ 20% (plus apo\n",
     "stability if `PBD_APO=1`). It's reported as *context*; the deliverable is the **ranked shortlist** —\n",
-    "the highest-confidence complexes to carry forward. Against\n",
-    "a hard target like the RBD you often won't clear the absolute bar at demo scale; what matters is that\n",
-    "Boltz-2, an **independent** model, consistently separates the better designs, and that scaling\n",
+    "the highest-confidence complexes to carry forward. On a **designable** target like PD-L1 you should\n",
+    "see designs clear the bar; on a harder target (e.g. the SARS-CoV-2 RBD) you often won't at demo\n",
+    "scale — but either way Boltz-2, an **independent** model, consistently separates the better designs,\n",
+    "and scaling\n",
     "`PBD_NUM_SAMPLES` / `PBD_N_ASSESS` (or `OPENHACKATHON_DEMO_MODE=0`) pushes the top of the ranking up."
    ]
   },
@@ -499,7 +502,7 @@
    "source": [
     "## 9. Stage 5 — Mol\\* view of the #1 ranked binder–target complex\n",
     "\n",
-    "The top binder by Boltz-2 co-folding ipTM: binder (orange) docked onto the RBD (gray), with\n",
+    "The top binder by Boltz-2 co-folding ipTM: binder (orange) docked onto PD-L1 (gray), with\n",
     "conditioned hotspots (red). A good design wraps the binder over the hotspot patch with high\n",
     "interface confidence."
    ]
@@ -510,7 +513,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Boltz-2 embeds the holo complex CIF inside validation/raw/<id>.json (chain A = target/RBD,\n",
+    "# Boltz-2 embeds the holo complex CIF inside validation/raw/<id>.json (chain A = target/PD-L1,\n",
     "# chain B = designed binder). The apo CIFs are the binder alone, so pull the holo complex here.\n",
     "mol = None\n",
     "top = df.iloc[0].to_dict() if not df.empty else {}\n",

--- a/examples/resources/bionemo-protein-binder-design-launchable/README.md
+++ b/examples/resources/bionemo-protein-binder-design-launchable/README.md
@@ -33,14 +33,15 @@ Everything else is fetched at deploy time by `setup.sh` (Proteina-Complexa + wei
 [bionemo-agent-toolkit](https://github.com/NVIDIA-BioNeMo/bionemo-agent-toolkit) skill, ipSAE,
 AF2-Multimer params, the Boltz-2 NIM image, and Python deps).
 
-## Target: SARS-CoV-2 spike RBD
+## Target: PD-L1 (cancer immunotherapy)
 
-Binders are designed against the **Receptor-Binding Domain** of the SARS-CoV-2 spike (registered
-Complexa target **`30_SC2RBD`**, PDB `6M0J`, span `E333-526`, hotspots `E485/E489/E494/E500/E505`,
-binder length 80–120 aa). The RBD engages human **ACE2** to enter cells, so a binder covering this
-interface blocks viral entry — the basis of neutralizing antibody and de novo-minibinder
-therapeutics. Swap `PBD_TARGET` for any of the ~44 registered targets (`complexa target list`:
-PD-L1, IL-17A, TNFα, VEGFA, HER2, …).
+Binders are designed against **PD-L1** (Programmed death-ligand 1 / CD274; registered Complexa target
+**`32_PDL1_ALPHA`**, PDB `5O45`, span `A17-132`, hotspots `A56/A115/A123`, binder length 50–120 aa).
+Tumors display PD-L1, which engages **PD-1** on T cells to switch them off (an immune *checkpoint*); a
+binder covering PD-L1's PD-1-binding face blocks that checkpoint and re-activates anti-tumor T cells —
+the mechanism of approved checkpoint inhibitors (atezolizumab, durvalumab, avelumab). PD-L1 is a
+well-behaved, highly *designable* target. Swap `PBD_TARGET` for any of the ~44 registered targets
+(`complexa target list`: IL-7Rα, TrkA, VEGF-A, TNFα, HER2, or the SARS-CoV-2 RBD `30_SC2RBD`, …).
 
 ## Deploy on Brev (Console wizard)
 
@@ -79,7 +80,7 @@ configuration from environment variables (with sensible defaults):
 | Env var | Default (DEMO) | Meaning |
 |---------|----------------|---------|
 | `OPENHACKATHON_DEMO_MODE` | `1` | `1` = 48/24/5/75 (pool/assess/diffusion/steps); `0` = 96/64/8/100 |
-| `PBD_TARGET` | `30_SC2RBD` | any registered Complexa target |
+| `PBD_TARGET` | `32_PDL1_ALPHA` | any registered Complexa target (PD-L1 default) |
 | `PBD_ALGORITHM` | `single-pass` | broad sampling; or `best-of-n` / `beam` for reward-guided search |
 | `PBD_AF2_REWARD` | `0` | `1` turns on the AF2-Multimer reward (only with `best-of-n`; slower) |
 | `PBD_NUM_SAMPLES` | `48` | size of the generated pool |
@@ -105,7 +106,8 @@ so for a more reliably gate-passing top binder, raise the pool (`PBD_NUM_SAMPLES
 **Co-folding gate (ipSAE-excluded):** ipTM ≥ 0.65, complex & binder pLDDT ≥ 0.70, ≥ 20% hotspot
 contact (plus apo-binder pLDDT ≥ 0.70 and apo↔holo RMSD ≤ 2.5 Å when `PBD_APO=1`). **ipSAE is
 excluded** because it's unavailable on Boltz-2's PAE and reads 0. The notebook ranks by ipTM and
-reports the **top-K**; clearing every bar on a hard target like the RBD generally needs scale.
+reports the **top-K**. PD-L1 is designable, so designs should clear the gate; on a harder target
+(e.g. the SARS-CoV-2 RBD) clearing every bar generally needs scale.
 
 **Seeing the 3D Mol\* widgets.** The embedded Mol\* views need the JupyterLab **front-end** to have
 the `anywidget` / `ipywidgets` extensions. `setup.sh` serves a widget-capable JupyterLab on `:8888`;


### PR DESCRIPTION
## Summary
The SARS-CoV-2 RBD is one of the harder targets in the set (small, mostly convex ACE2 interface), so demo designs rarely clear the gate. This switches the default target to **PD-L1** (`32_PDL1_ALPHA`, PDB 5O45, span A17-132, hotspots A56/A115/A123, binder 50–120 aa) — a well-behaved, highly designable cancer-immunotherapy target where demo designs actually pass the co-folding gate.

Updates the default, the notebook narrative (PD-L1 biology / hotspots), architecture diagram, Mol* captions, and the README target section + config table. The RBD is kept as an alternative "harder target" example.

## Test plan
- [x] notebook cells compile
- [ ] Fresh deploy on PD-L1: designs clear the ipTM-excluded co-folding gate