### PR TITLE
Stop printing validate_binders' misleading ipSAE-inclusive gate verdict

### DIFF
--- a/examples/resources/bionemo-protein-binder-design-launchable/Complexa_Binder_Design.ipynb
+++ b/examples/resources/bionemo-protein-binder-design-launchable/Complexa_Binder_Design.ipynb
@@ -372,11 +372,14 @@
     "    f\"--target-chain A --binder-chain B --hotspots '{hotspots_json}' {apo_flag}\"\n",
     ")\n",
     "print(score_cmd, \"\\n\")\n",
-    "rc, out = sh(score_cmd, timeout=10800)\n",
-    "print(\"assessment rc=\", rc)\n",
-    "print(\"\\nNOTE: validate_binders' 'PASS the gate' line above INCLUDES ipSAE, which is unavailable on \"\n",
-    "      \"Boltz-2's PAE and reads 0 -> that gate can never pass. Stage 4 below uses the ipSAE-excluded \"\n",
-    "      \"co-folding gate + ranking instead.\")"
+    "# Run quietly: validate_binders prints its OWN gate verdict that includes ipSAE (unavailable on\n",
+    "# Boltz-2 PAE -> 0), which always says \"0 PASS\" and confuses. We only need its metrics\n",
+    "# (ranked_binders.json); Stage 4 applies the ipSAE-excluded gate. Show output only on error.\n",
+    "rc, out = sh(score_cmd, timeout=10800, stream=False)\n",
+    "if rc != 0:\n",
+    "    print(out[-2500:])\n",
+    "print(f\"co-folded + scored the shortlist -> ranked_binders.json  (rc={rc}).\")\n",
+    "print(\"Head to Stage 4 for the result: it applies the ipSAE-EXCLUDED co-folding gate + ranking.\")"
    ]
   },
   {


### PR DESCRIPTION
validate_binders prints its own 'PASS the gate' verdict that includes ipSAE (unavailable on Boltz-2's PAE -> 0), so it always says '0 PASS' and reads as 'everything failed' even when designs are strong. This runs it quietly (we only need its metrics -> ranked_binders.json) and points to Stage 4's ipSAE-excluded co-folding gate for the authoritative result.